### PR TITLE
Fix exec dellocal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ APP := build/chain33
 CHAIN33=github.com/33cn/chain33
 CHAIN33_PATH=vendor/${CHAIN33}
 LDFLAGS := -ldflags "-w -s"
+PKG_LIST_VET := `go list ./... | grep -v "vendor"`
 PKG_LIST := `go list ./... | grep -v "vendor" | grep -v "chain33/test" | grep -v "mocks" | grep -v "pbft"`
 PKG_LIST_Q := `go list ./... | grep -v "vendor" | grep -v "chain33/test" | grep -v "mocks" | grep -v "blockchain" | grep -v "pbft"`
 BUILD_FLAGS = -ldflags "-X github.com/33cn/chain33/common/version.GitCommit=`git rev-parse --short=8 HEAD`"
@@ -35,6 +36,8 @@ build_ci: depends ## Build the binary file for CI
 para:
 	@go build -v -o build/$(NAME) -ldflags "-X $(SRC_CLI)/buildflags.ParaName=user.p.$(NAME). -X $(SRC_CLI)/buildflags.RPCAddr=http://localhost:8901" $(SRC_CLI)
 
+vet:
+	@go vet ${PKG_LIST_VET}
 
 autotest: ## build autotest binary
 	@cd build/autotest && bash ./build.sh && cd ../../
@@ -261,3 +264,22 @@ push:
 	git checkout ${b}
 	git merge master
 	git push origin ${b}
+
+pull:
+	@remotelist=$$(git remote | grep ${name});if [ -z $$remotelist ]; then \
+		echo ${remotelist}; \
+		git remote add ${name} https://github.com/${name}/plugin.git ; \
+	fi;
+	git fetch ${name}
+	git checkout ${name}/${b}
+	git checkout -b ${name}-${b}
+pullsync:
+	git fetch ${name}
+	git checkout ${name}-${b}
+	git merge ${name}/${b}
+pullpush:
+	@if [ -n "$$m" ]; then \
+	git commit -a -m "${m}" ; \
+	fi;
+	make pullsync
+	git push ${name} ${name}-${b}:${b}

--- a/plugin/dapp/lottery/executor/exec_del_local.go
+++ b/plugin/dapp/lottery/executor/exec_del_local.go
@@ -43,20 +43,20 @@ func (l *Lottery) execDelLocal(tx *types.Transaction, receiptData *types.Receipt
 
 // ExecDelLocal_Create Action
 func (l *Lottery) ExecDelLocal_Create(payload *pty.LotteryCreate, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return l.execDelLocal(tx, receiptData)
 }
 
 // ExecDelLocal_Buy Action
 func (l *Lottery) ExecDelLocal_Buy(payload *pty.LotteryBuy, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return l.execDelLocal(tx, receiptData)
 }
 
 // ExecDelLocal_Draw Action
 func (l *Lottery) ExecDelLocal_Draw(payload *pty.LotteryDraw, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return l.execDelLocal(tx, receiptData)
 }
 
 // ExecDelLocal_Close Action
 func (l *Lottery) ExecDelLocal_Close(payload *pty.LotteryClose, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return l.execDelLocal(tx, receiptData)
 }

--- a/plugin/dapp/retrieve/executor/exec_del_local.go
+++ b/plugin/dapp/retrieve/executor/exec_del_local.go
@@ -49,7 +49,7 @@ func DelRetrieveInfo(info *rt.RetrieveQuery, Status int64, db dbm.KVDB) (*types.
 }
 
 // ExecDelLocal_Backup Action
-func (c *Retrieve) ExecDelLocal_Backup(backup *rt.BackupRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
+func (c *Retrieve) ExecDelLocal_Backup(backup *rt.BackupRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
 	set := &types.LocalDBSet{}
 	if receiptData.GetTy() != types.ExecOk {
 		return set, nil
@@ -70,7 +70,7 @@ func (c *Retrieve) ExecDelLocal_Backup(backup *rt.BackupRetrieve, tx *types.Tran
 }
 
 // ExecDelLocal_Prepare Action
-func (c *Retrieve) ExecDelLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
+func (c *Retrieve) ExecDelLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
 	set := &types.LocalDBSet{}
 	if receiptData.GetTy() != types.ExecOk {
 		return set, nil
@@ -91,7 +91,7 @@ func (c *Retrieve) ExecDelLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Trans
 }
 
 // ExecDelLocal_Perform Action
-func (c *Retrieve) ExecDelLocal_Perform(perf *rt.PerformRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
+func (c *Retrieve) ExecDelLocal_Perform(perf *rt.PerformRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
 	set := &types.LocalDBSet{}
 	if receiptData.GetTy() != types.ExecOk {
 		return set, nil
@@ -112,7 +112,7 @@ func (c *Retrieve) ExecDelLocal_Perform(perf *rt.PerformRetrieve, tx *types.Tran
 }
 
 // ExecDelLocal_Cancel Action
-func (c *Retrieve) ExecDelLocal_Cancel(cancel *rt.CancelRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
+func (c *Retrieve) ExecDelLocal_Cancel(cancel *rt.CancelRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
 	set := &types.LocalDBSet{}
 	if receiptData.GetTy() != types.ExecOk {
 		return set, nil

--- a/plugin/dapp/retrieve/executor/exec_del_local.go
+++ b/plugin/dapp/retrieve/executor/exec_del_local.go
@@ -48,20 +48,13 @@ func DelRetrieveInfo(info *rt.RetrieveQuery, Status int64, db dbm.KVDB) (*types.
 	}
 }
 
-func (c *Retrieve) execDelLocal(tx *types.Transaction, receipt *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	set, err := c.DriverBase.ExecDelLocal(tx, receipt, index)
-	if err != nil {
-		return nil, err
-	}
-	if receipt.GetTy() != types.ExecOk {
-		return set, nil
-	}
-	return set, nil
-}
-
 // ExecDelLocal_Backup Action
 func (c *Retrieve) ExecDelLocal_Backup(backup *rt.BackupRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execDelLocal(tx, receiptData, index)
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecDelLocal_Backup")
 
 	info := rt.RetrieveQuery{BackupAddress: backup.BackupAddress, DefaultAddress: backup.DefaultAddress, DelayPeriod: backup.DelayPeriod, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrieveBackup}
 	kv, err := DelRetrieveInfo(&info, retrieveBackup, c.GetLocalDB())
@@ -78,7 +71,11 @@ func (c *Retrieve) ExecDelLocal_Backup(backup *rt.BackupRetrieve, tx *types.Tran
 
 // ExecDelLocal_Prepare Action
 func (c *Retrieve) ExecDelLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execDelLocal(tx, receiptData, index)
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecDelLocal_Prepare")
 
 	info := rt.RetrieveQuery{BackupAddress: pre.BackupAddress, DefaultAddress: pre.DefaultAddress, DelayPeriod: zeroDelay, PrepareTime: c.GetBlockTime(), RemainTime: zeroRemainTime, Status: retrievePrepare}
 	kv, err := DelRetrieveInfo(&info, retrievePrepare, c.GetLocalDB())
@@ -95,7 +92,11 @@ func (c *Retrieve) ExecDelLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Trans
 
 // ExecDelLocal_Perform Action
 func (c *Retrieve) ExecDelLocal_Perform(perf *rt.PerformRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execDelLocal(tx, receiptData, index)
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecDelLocal_Perform")
 
 	info := rt.RetrieveQuery{BackupAddress: perf.BackupAddress, DefaultAddress: perf.DefaultAddress, DelayPeriod: zeroDelay, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrievePerform}
 	kv, err := DelRetrieveInfo(&info, retrievePerform, c.GetLocalDB())
@@ -112,7 +113,11 @@ func (c *Retrieve) ExecDelLocal_Perform(perf *rt.PerformRetrieve, tx *types.Tran
 
 // ExecDelLocal_Cancel Action
 func (c *Retrieve) ExecDelLocal_Cancel(cancel *rt.CancelRetrieve, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execDelLocal(tx, receiptData, index)
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecDelLocal_Cancel")
 
 	info := rt.RetrieveQuery{BackupAddress: cancel.BackupAddress, DefaultAddress: cancel.DefaultAddress, DelayPeriod: zeroDelay, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrieveCancel}
 	kv, err := DelRetrieveInfo(&info, retrieveCancel, c.GetLocalDB())

--- a/plugin/dapp/retrieve/executor/exec_local.go
+++ b/plugin/dapp/retrieve/executor/exec_local.go
@@ -51,19 +51,13 @@ func SaveRetrieveInfo(info *rt.RetrieveQuery, Status int64, db dbm.KVDB) (*types
 	}
 }
 
-func (c *Retrieve) execLocal(receipt types.ExecTypeGet) (*types.LocalDBSet, error) {
-	dbSet := &types.LocalDBSet{}
-	if receipt.GetTy() != types.ExecOk {
-		return dbSet, nil
-	}
-	rlog.Debug("Retrieve ExecLocal")
-	return dbSet, nil
-}
-
 // ExecLocal_Backup Action
 func (c *Retrieve) ExecLocal_Backup(backup *rt.BackupRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execLocal(receiptData)
-
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecLocal_Backup")
 	info := rt.RetrieveQuery{BackupAddress: backup.BackupAddress, DefaultAddress: backup.DefaultAddress, DelayPeriod: backup.DelayPeriod, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrieveBackup}
 	kv, err := SaveRetrieveInfo(&info, retrieveBackup, c.GetLocalDB())
 	if err != nil {
@@ -79,7 +73,11 @@ func (c *Retrieve) ExecLocal_Backup(backup *rt.BackupRetrieve, tx *types.Transac
 
 // ExecLocal_Prepare Action
 func (c *Retrieve) ExecLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execLocal(receiptData)
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecLocal_Prepare")
 
 	info := rt.RetrieveQuery{BackupAddress: pre.BackupAddress, DefaultAddress: pre.DefaultAddress, DelayPeriod: zeroDelay, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrievePrepare}
 	kv, err := SaveRetrieveInfo(&info, retrievePrepare, c.GetLocalDB())
@@ -94,9 +92,13 @@ func (c *Retrieve) ExecLocal_Prepare(pre *rt.PrepareRetrieve, tx *types.Transact
 	return set, nil
 }
 
-// ExecLocal_Perf Action
-func (c *Retrieve) ExecLocal_Perf(perf *rt.PerformRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execLocal(receiptData)
+// ExecLocal_Perform Action
+func (c *Retrieve) ExecLocal_Perform(perf *rt.PerformRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecLocal_Perf")
 
 	info := rt.RetrieveQuery{BackupAddress: perf.BackupAddress, DefaultAddress: perf.DefaultAddress, DelayPeriod: zeroDelay, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrievePerform}
 	kv, err := SaveRetrieveInfo(&info, retrievePerform, c.GetLocalDB())
@@ -113,7 +115,11 @@ func (c *Retrieve) ExecLocal_Perf(perf *rt.PerformRetrieve, tx *types.Transactio
 
 // ExecLocal_Cancel Action
 func (c *Retrieve) ExecLocal_Cancel(cancel *rt.CancelRetrieve, tx *types.Transaction, receiptData types.ExecTypeGet, index int) (*types.LocalDBSet, error) {
-	set, _ := c.execLocal(receiptData)
+	set := &types.LocalDBSet{}
+	if receiptData.GetTy() != types.ExecOk {
+		return set, nil
+	}
+	rlog.Debug("Retrieve ExecLocal_Cancel")
 
 	info := rt.RetrieveQuery{BackupAddress: cancel.BackupAddress, DefaultAddress: cancel.DefaultAddress, DelayPeriod: zeroDelay, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrieveCancel}
 	kv, err := SaveRetrieveInfo(&info, retrieveCancel, c.GetLocalDB())

--- a/plugin/dapp/retrieve/executor/retrieve_unit_test.go
+++ b/plugin/dapp/retrieve/executor/retrieve_unit_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/33cn/chain33/common/crypto"
 	"github.com/33cn/chain33/common/db"
+	"github.com/33cn/chain33/executor"
 	drivers "github.com/33cn/chain33/system/dapp"
 	"github.com/33cn/chain33/types"
 	rt "github.com/33cn/plugin/plugin/dapp/retrieve/types"
@@ -33,6 +34,9 @@ func init() {
 	retrieve = constructRetrieveInstance()
 }
 
+func NewTestDB() db.KV {
+	return executor.NewStateDB(nil, nil, nil, &executor.StateDBOption{Height: types.GetFork("ForkExecRollback")})
+}
 func TestExecBackup(t *testing.T) {
 	var targetReceipt types.Receipt
 	var targetErr error
@@ -359,36 +363,4 @@ func (e *TestLDB) List(prefix, key []byte, count, direction int32) ([][]byte, er
 
 func (e *TestLDB) PrefixCount(prefix []byte) int64 {
 	return 0
-}
-
-type TestDB struct {
-	db.TransactionDB
-	cache map[string][]byte
-}
-
-func NewTestDB() *TestDB {
-	return &TestDB{cache: make(map[string][]byte)}
-}
-
-func (e *TestDB) Get(key []byte) (value []byte, err error) {
-	if value, ok := e.cache[string(key)]; ok {
-		//elog.Error("getkey", "key", string(key), "value", string(value))
-		return value, nil
-	}
-	return nil, types.ErrNotFound
-}
-
-func (e *TestDB) Set(key []byte, value []byte) error {
-	//elog.Error("setkey", "key", string(key), "value", string(value))
-	e.cache[string(key)] = value
-	return nil
-}
-
-func (e *TestDB) BatchGet(keys [][]byte) (values [][]byte, err error) {
-	return nil, types.ErrNotFound
-}
-
-//从数据库中查询数据列表，set 中的cache 更新不会影响这个list
-func (e *TestDB) List(prefix, key []byte, count, direction int32) ([][]byte, error) {
-	return nil, types.ErrNotFound
 }

--- a/plugin/dapp/retrieve/executor/retrieve_unit_test.go
+++ b/plugin/dapp/retrieve/executor/retrieve_unit_test.go
@@ -5,6 +5,7 @@
 package executor
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"testing"
@@ -75,9 +76,163 @@ func TestExecPerform(t *testing.T) {
 	}
 }
 
+func TestExecLocalBackup(t *testing.T) {
+	var targetDBSet types.LocalDBSet
+	var targetErr error
+	var dbset *types.LocalDBSet
+	var err error
+
+	info := rt.RetrieveQuery{BackupAddress: backupAddr, DefaultAddress: defaultAddr, DelayPeriod: 70, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrieveBackup}
+	value := types.Encode(&info)
+
+	kv := &types.KeyValue{Key: calcRetrieveKey(backupAddr, defaultAddr), Value: value}
+	targetDBSet.KV = append(targetDBSet.KV, kv)
+
+	tx := ConstructBackupTx()
+	var receiptData types.ReceiptData
+	receiptData.Ty = types.ExecOk
+
+	dbset, err = retrieve.ExecLocal(tx, &receiptData, 0)
+	if err != nil {
+		t.Error(testNormErr)
+	}
+
+	if !CompareRetrieveExecLocalRes(&targetDBSet, err, dbset, targetErr) {
+		t.Error(testNormErr)
+	}
+}
+
+func TestExecLocalPrepare(t *testing.T) {
+	var targetDBSet types.LocalDBSet
+	var targetErr error
+	var dbset *types.LocalDBSet
+	var err error
+
+	info := rt.RetrieveQuery{BackupAddress: backupAddr, DefaultAddress: defaultAddr, DelayPeriod: 70, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrievePrepare}
+	value := types.Encode(&info)
+
+	kv := &types.KeyValue{Key: calcRetrieveKey(backupAddr, defaultAddr), Value: value}
+	targetDBSet.KV = append(targetDBSet.KV, kv)
+
+	tx := ConstructPrepareTx()
+	var receiptData types.ReceiptData
+	receiptData.Ty = types.ExecOk
+
+	dbset, err = retrieve.ExecLocal(tx, &receiptData, 0)
+	if err != nil {
+		t.Error(testNormErr)
+	}
+
+	if !CompareRetrieveExecLocalRes(&targetDBSet, err, dbset, targetErr) {
+		t.Error(testNormErr)
+	}
+}
+
+func TestExecLocalPerform(t *testing.T) {
+	var targetDBSet types.LocalDBSet
+	var targetErr error
+	var dbset *types.LocalDBSet
+	var err error
+
+	info := rt.RetrieveQuery{BackupAddress: backupAddr, DefaultAddress: defaultAddr, DelayPeriod: 70, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrievePerform}
+	value := types.Encode(&info)
+
+	kv := &types.KeyValue{Key: calcRetrieveKey(backupAddr, defaultAddr), Value: value}
+	targetDBSet.KV = append(targetDBSet.KV, kv)
+
+	tx := ConstructPerformTx()
+	var receiptData types.ReceiptData
+	receiptData.Ty = types.ExecOk
+
+	dbset, err = retrieve.ExecLocal(tx, &receiptData, 0)
+	if err != nil {
+		t.Error(testNormErr)
+	}
+
+	if !CompareRetrieveExecLocalRes(&targetDBSet, err, dbset, targetErr) {
+		t.Error(testNormErr)
+	}
+}
+
+func TestExecDelLocalPerform(t *testing.T) {
+	var targetDBSet types.LocalDBSet
+	var targetErr error
+	var dbset *types.LocalDBSet
+	var err error
+
+	info := rt.RetrieveQuery{BackupAddress: backupAddr, DefaultAddress: defaultAddr, DelayPeriod: 70, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrievePrepare}
+	value := types.Encode(&info)
+
+	kv := &types.KeyValue{Key: calcRetrieveKey(backupAddr, defaultAddr), Value: value}
+	targetDBSet.KV = append(targetDBSet.KV, kv)
+
+	tx := ConstructPerformTx()
+	var receiptData types.ReceiptData
+	receiptData.Ty = types.ExecOk
+
+	dbset, err = retrieve.ExecDelLocal(tx, &receiptData, 0)
+	if err != nil {
+		t.Error(testNormErr)
+	}
+
+	if !CompareRetrieveExecLocalRes(&targetDBSet, err, dbset, targetErr) {
+		t.Error(testNormErr)
+	}
+}
+
+func TestExecDelLocalPrepare(t *testing.T) {
+	var targetDBSet types.LocalDBSet
+	var targetErr error
+	var dbset *types.LocalDBSet
+	var err error
+
+	info := rt.RetrieveQuery{BackupAddress: backupAddr, DefaultAddress: defaultAddr, DelayPeriod: 70, PrepareTime: zeroPrepareTime, RemainTime: zeroRemainTime, Status: retrieveBackup}
+	value := types.Encode(&info)
+
+	kv := &types.KeyValue{Key: calcRetrieveKey(backupAddr, defaultAddr), Value: value}
+	targetDBSet.KV = append(targetDBSet.KV, kv)
+
+	tx := ConstructPrepareTx()
+	var receiptData types.ReceiptData
+	receiptData.Ty = types.ExecOk
+
+	dbset, err = retrieve.ExecDelLocal(tx, &receiptData, 0)
+	if err != nil {
+		t.Error(testNormErr)
+	}
+
+	if !CompareRetrieveExecLocalRes(&targetDBSet, err, dbset, targetErr) {
+		t.Error(testNormErr)
+	}
+}
+
+func TestExecDelLocalBackup(t *testing.T) {
+	var targetDBSet types.LocalDBSet
+	var targetErr error
+	var dbset *types.LocalDBSet
+	var err error
+
+	kv := &types.KeyValue{Key: calcRetrieveKey(backupAddr, defaultAddr), Value: nil}
+	targetDBSet.KV = append(targetDBSet.KV, kv)
+
+	tx := ConstructBackupTx()
+	var receiptData types.ReceiptData
+	receiptData.Ty = types.ExecOk
+
+	dbset, err = retrieve.ExecDelLocal(tx, &receiptData, 0)
+	if err != nil {
+		t.Error(testNormErr)
+	}
+
+	if !CompareRetrieveExecLocalRes(&targetDBSet, err, dbset, targetErr) {
+		t.Error(testNormErr)
+	}
+}
+
 func constructRetrieveInstance() drivers.Driver {
 	r := newRetrieve()
 	r.SetStateDB(NewTestDB())
+	r.SetLocalDB(NewTestLDB())
 	return r
 }
 
@@ -118,6 +273,43 @@ func ConstructPerformTx() *types.Transaction {
 	return tx
 }
 
+func CompareRetrieveExecLocalRes(dbset1 *types.LocalDBSet, err1 error, dbset2 *types.LocalDBSet, err2 error) bool {
+	//fmt.Println(err1, err2, dbset1, dbset2)
+	if err1 != err2 {
+		fmt.Println(err1, err2)
+		return false
+	}
+
+	if dbset1 == nil && dbset2 == nil {
+		return true
+	}
+
+	if (dbset1 == nil) != (dbset2 == nil) {
+		return false
+	}
+
+	if dbset1.KV == nil && dbset2.KV == nil {
+		return true
+	}
+
+	if (dbset1.KV == nil) != (dbset2.KV == nil) {
+		return false
+	}
+	if len(dbset1.KV) != len(dbset2.KV) {
+		return false
+	}
+
+	for i := range dbset1.KV {
+		if !bytes.Equal(dbset1.KV[i].Key, dbset2.KV[i].Key) {
+			return false
+		}
+		if !bytes.Equal(dbset1.KV[i].Value, dbset2.KV[i].Value) {
+			return false
+		}
+	}
+	return true
+}
+
 func CompareRetrieveExecResult(rec1 *types.Receipt, err1 error, rec2 *types.Receipt, err2 error) bool {
 	if err1 != err2 {
 		fmt.Println(err1, err2)
@@ -131,6 +323,42 @@ func CompareRetrieveExecResult(rec1 *types.Receipt, err1 error, rec2 *types.Rece
 		return false
 	}
 	return true
+}
+
+type TestLDB struct {
+	db.TransactionDB
+	cache map[string][]byte
+}
+
+func NewTestLDB() *TestLDB {
+	return &TestLDB{cache: make(map[string][]byte)}
+}
+
+func (e *TestLDB) Get(key []byte) (value []byte, err error) {
+	if value, ok := e.cache[string(key)]; ok {
+		//elog.Error("getkey", "key", string(key), "value", string(value))
+		return value, nil
+	}
+	return nil, types.ErrNotFound
+}
+
+func (e *TestLDB) Set(key []byte, value []byte) error {
+	//elog.Error("setkey", "key", string(key), "value", string(value))
+	e.cache[string(key)] = value
+	return nil
+}
+
+func (e *TestLDB) BatchGet(keys [][]byte) (values [][]byte, err error) {
+	return nil, types.ErrNotFound
+}
+
+//从数据库中查询数据列表，set 中的cache 更新不会影响这个list
+func (e *TestLDB) List(prefix, key []byte, count, direction int32) ([][]byte, error) {
+	return nil, types.ErrNotFound
+}
+
+func (e *TestLDB) PrefixCount(prefix []byte) int64 {
+	return 0
 }
 
 type TestDB struct {

--- a/plugin/dapp/ticket/executor/exec_del_local.go
+++ b/plugin/dapp/ticket/executor/exec_del_local.go
@@ -39,25 +39,25 @@ func (t *Ticket) execDelLocal(receiptData *types.ReceiptData) (*types.LocalDBSet
 
 // ExecDelLocal_Genesis exec del local genesis
 func (t *Ticket) ExecDelLocal_Genesis(payload *ty.TicketGenesis, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return t.execDelLocal(receiptData)
 }
 
 // ExecDelLocal_Topen exec del local open
 func (t *Ticket) ExecDelLocal_Topen(payload *ty.TicketOpen, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return t.execDelLocal(receiptData)
 }
 
 // ExecDelLocal_Tbind exec del local bind
 func (t *Ticket) ExecDelLocal_Tbind(payload *ty.TicketBind, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return t.execDelLocal(receiptData)
 }
 
 // ExecDelLocal_Tclose exec del local close
 func (t *Ticket) ExecDelLocal_Tclose(payload *ty.TicketClose, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return t.execDelLocal(receiptData)
 }
 
 // ExecDelLocal_Miner exec del local miner
 func (t *Ticket) ExecDelLocal_Miner(payload *ty.TicketMiner, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
-	return nil, nil
+	return t.execDelLocal(receiptData)
 }

--- a/plugin/dapp/ticket/rpc/rpc_test.go
+++ b/plugin/dapp/ticket/rpc/rpc_test.go
@@ -43,8 +43,8 @@ func TestChannelClient_BindMiner(t *testing.T) {
 	storevalue.Values = append(storevalue.Values, accv)
 	api.On("StoreGet", mock.Anything).Return(storevalue, nil)
 
-	var addrs = make([]string, 1)
-	addrs = append(addrs, "1Jn2qu84Z1SUUosWjySggBS9pKWdAP3tZt")
+	//var addrs = make([]string, 1)
+	//addrs = append(addrs, "1Jn2qu84Z1SUUosWjySggBS9pKWdAP3tZt")
 	var in = &ty.ReqBindMiner{
 		BindAddr:     "1Jn2qu84Z1SUUosWjySggBS9pKWdAP3tZt",
 		OriginAddr:   "1Jn2qu84Z1SUUosWjySggBS9pKWdAP3tZt",

--- a/vendor/github.com/33cn/chain33/common/db/list_helper.go
+++ b/vendor/github.com/33cn/chain33/common/db/list_helper.go
@@ -6,7 +6,6 @@ package db
 
 import (
 	"bytes"
-	"fmt"
 
 	log "github.com/33cn/chain33/common/log/log15"
 )
@@ -173,22 +172,22 @@ func (db *ListHelper) IteratorCallback(start []byte, end []byte, count int32, di
 		if end != nil {
 			cmp := bytes.Compare(key, end)
 			if !reserse && cmp > 0 {
-				fmt.Println("break1")
+				listlog.Debug("break1")
 				break
 			}
 			if reserse && cmp < 0 {
-				fmt.Println("break2")
+				listlog.Debug("break2")
 				break
 			}
 		}
 		if fn(cloneByte(key), cloneByte(value)) {
-			fmt.Println("break3")
+			listlog.Debug("break3")
 			break
 		}
 		//count 到数目了
 		i++
 		if i == count {
-			fmt.Println("break4")
+			listlog.Debug("break4")
 			break
 		}
 	}


### PR DESCRIPTION
#49 #23 #25 
修改lottery, ticket, retrieve执行器的execDelLocal错误，并添加部分单元测试用例
retrieve执行器本地执行时会调用localDB的Get，尝试mock暂时没有成功，单元测试暂时独立封装LocalDB
