### PR TITLE
add by hyb for setTicket input param check

### DIFF
--- a/plugin/consensus/ticket/ticket.go
+++ b/plugin/consensus/ticket/ticket.go
@@ -201,6 +201,11 @@ func (client *Client) setTicket(tlist *ty.ReplyTicketList, privmap map[string]cr
 	client.ticketmu.Lock()
 	defer client.ticketmu.Unlock()
 	client.ticketsMap = make(map[string]*ty.Ticket)
+	if tlist == nil || privmap == nil {
+		client.ticketsMap = nil
+		client.privmap = nil
+		return
+	}
 	for _, ticket := range tlist.Tickets {
 		client.ticketsMap[ticket.GetTicketId()] = ticket
 	}

--- a/plugin/consensus/ticket/ticket_test.go
+++ b/plugin/consensus/ticket/ticket_test.go
@@ -118,6 +118,15 @@ func TestTicketMap(t *testing.T) {
 	assert.Equal(t, c.getTicketCount(), int64(4))
 	c.delTicket("3333")
 	assert.Equal(t, c.getTicketCount(), int64(3))
+
+	c.setTicket(ticketList, nil)
+	assert.Equal(t, c.getTicketCount(), int64(0))
+
+	c.setTicket(nil, privmap)
+	assert.Equal(t, c.getTicketCount(), int64(0))
+
+	c.setTicket(nil, nil)
+	assert.Equal(t, c.getTicketCount(), int64(0))
 }
 
 func TestProcEvent(t *testing.T) {

--- a/plugin/consensus/ticket/ticket_test.go
+++ b/plugin/consensus/ticket/ticket_test.go
@@ -104,8 +104,17 @@ func TestTicketMap(t *testing.T) {
 		{TicketId: "3333"},
 		{TicketId: "4444"},
 	}
+	privmap := make(map[string]crypto.PrivKey)
+	//通过privkey生成一个pubkey然后换算成对应的addr
+	cr, _ := crypto.New("secp256k1")
+	priv, _ := cr.PrivKeyFromBytes([]byte("2116459C0EC8ED01AA0EEAE35CAC5C96F94473F7816F114873291217303F6989"))
+	privmap["1111"] = priv
+	privmap["2222"] = priv
+	privmap["3333"] = priv
+	privmap["4444"] = priv
+
 	assert.Equal(t, c.getTicketCount(), int64(0))
-	c.setTicket(ticketList, nil)
+	c.setTicket(ticketList, privmap)
 	assert.Equal(t, c.getTicketCount(), int64(4))
 	c.delTicket("3333")
 	assert.Equal(t, c.getTicketCount(), int64(3))


### PR DESCRIPTION
issues109：setTicket 接口增加入参为nil的特殊处理，当输入的tlist为nil时将ticket信息设置成空，不再挖矿
client.ticketsMap = nil
client.privmap = nil
