### PR TITLE
paracross local: record tx hash in hex format

### DIFF
--- a/plugin/dapp/paracross/executor/exec_del_local.go
+++ b/plugin/dapp/paracross/executor/exec_del_local.go
@@ -5,6 +5,7 @@
 package executor
 
 import (
+	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/types"
 	pt "github.com/33cn/plugin/plugin/dapp/paracross/types"
 )
@@ -18,7 +19,7 @@ func (e *Paracross) ExecDelLocal_Commit(payload *pt.ParacrossCommitAction, tx *t
 			types.Decode(log.Log, &g)
 
 			var r pt.ParacrossTx
-			r.TxHash = string(tx.Hash())
+			r.TxHash = common.ToHex(tx.Hash())
 			set.KV = append(set.KV, &types.KeyValue{Key: calcLocalTxKey(g.Status.Title, g.Status.Height, tx.From()), Value: nil})
 		} else if log.Ty == pt.TyLogParacrossCommitDone {
 			var g pt.ReceiptParacrossDone
@@ -41,7 +42,7 @@ func (e *Paracross) ExecDelLocal_Commit(payload *pt.ParacrossCommitAction, tx *t
 			types.Decode(log.Log, &g)
 
 			var r pt.ParacrossTx
-			r.TxHash = string(tx.Hash())
+			r.TxHash = common.ToHex(tx.Hash())
 			set.KV = append(set.KV, &types.KeyValue{Key: calcLocalTxKey(g.Status.Title, g.Status.Height, tx.From()), Value: nil})
 		}
 	}

--- a/plugin/dapp/paracross/executor/exec_local.go
+++ b/plugin/dapp/paracross/executor/exec_local.go
@@ -7,6 +7,7 @@ package executor
 import (
 	"bytes"
 
+	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/types"
 	"github.com/33cn/chain33/util"
 	pt "github.com/33cn/plugin/plugin/dapp/paracross/types"
@@ -21,7 +22,7 @@ func (e *Paracross) ExecLocal_Commit(payload *pt.ParacrossCommitAction, tx *type
 			types.Decode(log.Log, &g)
 
 			var r pt.ParacrossTx
-			r.TxHash = string(tx.Hash())
+			r.TxHash = common.ToHex(tx.Hash())
 			set.KV = append(set.KV, &types.KeyValue{Key: calcLocalTxKey(g.Status.Title, g.Status.Height, tx.From()), Value: types.Encode(&r)})
 		} else if log.Ty == pt.TyLogParacrossCommitDone {
 			var g pt.ReceiptParacrossDone
@@ -43,7 +44,7 @@ func (e *Paracross) ExecLocal_Commit(payload *pt.ParacrossCommitAction, tx *type
 			types.Decode(log.Log, &g)
 
 			var r pt.ParacrossTx
-			r.TxHash = string(tx.Hash())
+			r.TxHash = common.ToHex(tx.Hash())
 			set.KV = append(set.KV, &types.KeyValue{Key: calcLocalTxKey(g.Status.Title, g.Status.Height, tx.From()), Value: types.Encode(&r)})
 		}
 	}


### PR DESCRIPTION
 protobuf 升级 string 不能包含 非utf8字符。

解决方式 使用hex格式保存

close #154 

