### PR TITLE
Multisig para

### DIFF
--- a/plugin/dapp/multisig/executor/multisig.go
+++ b/plugin/dapp/multisig/executor/multisig.go
@@ -887,7 +887,7 @@ func (m *MultiSig) getMultiSigAccAssets(multiSigAddr string, assets *mty.Assets)
 	}
 	var acc1 *types.Account
 
-	execaddress := dapp.ExecAddress(m.GetName())
+	execaddress := dapp.ExecAddress(types.ExecName(m.GetName()))
 	acc1 = acc.LoadExecAccount(multiSigAddr, execaddress)
 	return acc1, nil
 }


### PR DESCRIPTION
平行链上支持多重签名合约，修改查询多重签名合约中资产信息的接口，平行链需要使用加了前缀的合约地址