### PR TITLE
Asset update

### DIFF
--- a/plugin/dapp/paracross/commands/paracross.go
+++ b/plugin/dapp/paracross/commands/paracross.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/33cn/chain33/rpc/jsonclient"
+	"github.com/33cn/chain33/system/dapp/commands"
 	"github.com/33cn/chain33/types"
 	pt "github.com/33cn/plugin/plugin/dapp/paracross/types"
 	"github.com/spf13/cobra"
@@ -162,19 +163,12 @@ func addCreateTransferFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringP("note", "n", "", "transaction note info")
 
-	cmd.Flags().StringP("title", "", "", "the title of para chain, like `p.user.guodun.`")
-	cmd.MarkFlagRequired("title")
-
 	cmd.Flags().StringP("symbol", "s", "", "default for bty, symbol for token")
+	cmd.MarkFlagRequired("symbol")
 }
 
 func createTransfer(cmd *cobra.Command, args []string) {
-	txHex, err := createTransferTx(cmd, false)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	fmt.Println(txHex)
+	commands.CreateAssetTransfer(cmd, args, pt.ParaX)
 }
 
 //CreateRawTransferToExecCmd create raw transfer to exec tx
@@ -189,27 +183,20 @@ func CreateRawTransferToExecCmd() *cobra.Command {
 }
 
 func addCreateTransferToExecFlags(cmd *cobra.Command) {
-	cmd.Flags().StringP("to", "t", "", "receiver exec name")
-	cmd.MarkFlagRequired("to")
-
 	cmd.Flags().Float64P("amount", "a", 0, "transaction amount")
 	cmd.MarkFlagRequired("amount")
 
 	cmd.Flags().StringP("note", "n", "", "transaction note info")
 
-	cmd.Flags().StringP("title", "", "", "the title of para chain, like `p.user.guodun.`")
-	cmd.MarkFlagRequired("title")
+	cmd.Flags().StringP("symbol", "s", "coins.bty", "default for bty, symbol for token")
+	cmd.MarkFlagRequired("symbol")
 
-	cmd.Flags().StringP("symbol", "s", "", "default for bty, symbol for token")
+	cmd.Flags().StringP("exec", "e", "", "asset deposit exec")
+	cmd.MarkFlagRequired("exec")
 }
 
 func createTransferToExec(cmd *cobra.Command, args []string) {
-	txHex, err := createTransferTx(cmd, false)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	fmt.Println(txHex)
+	commands.CreateAssetSendToExec(cmd, args, pt.ParaX)
 }
 
 //CreateRawWithdrawCmd create raw withdraw tx
@@ -229,59 +216,15 @@ func addCreateWithdrawFlags(cmd *cobra.Command) {
 
 	cmd.Flags().StringP("note", "n", "", "transaction note info")
 
-	cmd.Flags().StringP("title", "", "", "the title of para chain, like `p.user.guodun.`")
-	cmd.MarkFlagRequired("title")
-
-	cmd.Flags().StringP("from", "t", "", "exec name")
-	cmd.MarkFlagRequired("from")
-
 	cmd.Flags().StringP("symbol", "s", "", "default for bty, symbol for token")
+	cmd.MarkFlagRequired("symbol")
+
+	cmd.Flags().StringP("exec", "e", "", "asset deposit exec")
+	cmd.MarkFlagRequired("exec")
 }
 
 func createWithdraw(cmd *cobra.Command, args []string) {
-	txHex, err := createTransferTx(cmd, true)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	fmt.Println(txHex)
-}
-
-func createTransferTx(cmd *cobra.Command, isWithdraw bool) (string, error) {
-	amount, _ := cmd.Flags().GetFloat64("amount")
-	if amount < 0 {
-		return "", types.ErrAmount
-	}
-	amountInt64 := int64(math.Trunc((amount+0.0000001)*1e4)) * 1e4
-
-	toAddr, _ := cmd.Flags().GetString("to")
-	note, _ := cmd.Flags().GetString("note")
-	symbol, _ := cmd.Flags().GetString("symbol")
-
-	title, _ := cmd.Flags().GetString("title")
-	if !strings.HasPrefix(title, "user.p") {
-		fmt.Fprintln(os.Stderr, "title is not right, title format like `user.p.guodun.`")
-		return "", types.ErrInvalidParam
-	}
-	execName := title + pt.ParaX
-
-	param := types.CreateTx{
-		To:          toAddr,
-		Amount:      amountInt64,
-		Fee:         0,
-		Note:        []byte(note),
-		IsWithdraw:  isWithdraw,
-		IsToken:     false,
-		TokenSymbol: symbol,
-		ExecName:    execName,
-	}
-	tx, err := pt.CreateRawTransferTx(&param)
-	if err != nil {
-		return "", err
-	}
-
-	txHex := types.Encode(tx)
-	return hex.EncodeToString(txHex), nil
+	commands.CreateAssetWithdraw(cmd, args, pt.ParaX)
 }
 
 // IsSyncCmd query parachain is sync

--- a/plugin/dapp/paracross/types/paracross.go
+++ b/plugin/dapp/paracross/types/paracross.go
@@ -5,7 +5,8 @@
 package types
 
 import (
-	fmt "fmt"
+	"encoding/json"
+	"fmt"
 
 	"github.com/33cn/chain33/common/address"
 	"github.com/33cn/chain33/common/log/log15"
@@ -187,34 +188,28 @@ func CreateRawMinerTx(status *ParacrossNodeStatus) (*types.Transaction, error) {
 }
 
 // CreateRawTransferTx create paracross asset transfer tx with transfer and withdraw
-func CreateRawTransferTx(param *types.CreateTx) (*types.Transaction, error) {
-	if !types.IsParaExecName(param.GetExecName()) {
-		tlog.Error("CreateRawTransferTx", "exec", param.GetExecName())
-		return nil, types.ErrInvalidParam
-	}
-
-	transfer := &ParacrossAction{}
-	if !param.IsWithdraw {
-		v := &ParacrossAction_Transfer{Transfer: &types.AssetsTransfer{
-			Amount: param.Amount, Note: param.GetNote(), To: param.GetTo(), Cointoken: param.TokenSymbol}}
-		transfer.Value = v
-		transfer.Ty = ParacrossActionTransfer
-	} else {
-		v := &ParacrossAction_Withdraw{Withdraw: &types.AssetsWithdraw{
-			Amount: param.Amount, Note: param.GetNote(), To: param.GetTo(), Cointoken: param.TokenSymbol}}
-		transfer.Value = v
-		transfer.Ty = ParacrossActionWithdraw
-	}
-	tx := &types.Transaction{
-		Execer:  []byte(param.GetExecName()),
-		Payload: types.Encode(transfer),
-		To:      address.ExecAddress(param.GetExecName()),
-		Fee:     param.Fee,
-	}
-	var err error
-	tx, err = types.FormatTx(param.GetExecName(), tx)
+func (p ParacrossType) CreateRawTransferTx(action string, param json.RawMessage) (*types.Transaction, error) {
+	tlog.Error("ParacrossType CreateTx failed", "action", action, "msg", string(param))
+	tx, err := p.ExecTypeBase.CreateTx(action, param)
 	if err != nil {
+		tlog.Error("ParacrossType CreateTx failed", "err", err, "action", action, "msg", string(param))
 		return nil, err
 	}
+	if !types.IsPara() {
+		var transfer ParacrossAction
+		err = types.Decode(tx.Payload, &transfer)
+		if err != nil {
+			tlog.Error("ParacrossType CreateTx failed", "decode payload err", err, "action", action, "msg", string(param))
+			return nil, err
+		}
+		if action == "Transfer" {
+			tx.To = transfer.GetTransfer().To
+		} else if action == "Withdraw" {
+			tx.To = transfer.GetWithdraw().To
+		} else if action == "TransferToExec" {
+			tx.To = transfer.GetTransferToExec().To
+		}
+	}
+
 	return tx, nil
 }

--- a/plugin/dapp/paracross/types/type.go
+++ b/plugin/dapp/paracross/types/type.go
@@ -98,15 +98,16 @@ func (p ParacrossType) CreateTx(action string, message json.RawMessage) (*types.
 		}
 		return CreateRawAssetTransferTx(&param)
 
-	} else if action == "ParacrossTransfer" || action == "ParacrossWithdraw" || action == "ParacrossTransferToExec" {
+	} else if action == "ParacrossTransfer" || action == "Transfer" ||
+		action == "ParacrossWithdraw" || action == "Withdraw" ||
+		action == "ParacrossTransferToExec" || action == "TransferToExec" {
 		var param types.CreateTx
 		err := json.Unmarshal(message, &param)
 		if err != nil {
 			glog.Error("CreateTx", "Error", err)
 			return nil, types.ErrInvalidParam
 		}
-		return CreateRawTransferTx(&param)
-
+		return p.CreateRawTransferTx(action, message)
 	}
 
 	return nil, types.ErrNotSupport

--- a/plugin/dapp/token/commands/token.go
+++ b/plugin/dapp/token/commands/token.go
@@ -7,13 +7,13 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"math"
 	"os"
 	"strconv"
 	"strings"
 
 	"github.com/33cn/chain33/rpc/jsonclient"
 	rpctypes "github.com/33cn/chain33/rpc/types"
+	"github.com/33cn/chain33/system/dapp/commands"
 	"github.com/33cn/chain33/types"
 	tokenty "github.com/33cn/plugin/plugin/dapp/token/types"
 	"github.com/spf13/cobra"
@@ -72,31 +72,7 @@ func addCreateTokenTransferFlags(cmd *cobra.Command) {
 }
 
 func createTokenTransfer(cmd *cobra.Command, args []string) {
-	toAddr, _ := cmd.Flags().GetString("to")
-	amount, _ := cmd.Flags().GetFloat64("amount")
-	note, _ := cmd.Flags().GetString("note")
-	symbol, _ := cmd.Flags().GetString("symbol")
-
-	payload := &types.AssetsTransfer{
-		To:        toAddr,
-		Amount:    int64(math.Trunc((amount+0.0000001)*1e4)) * 1e4,
-		Note:      []byte(note),
-		Cointoken: symbol,
-	}
-	data, err := json.Marshal(&payload)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	params := &rpctypes.CreateTxIn{
-		Execer:     types.ExecName(tokenty.TokenX),
-		ActionName: "Transfer",
-		Payload:    data,
-	}
-
-	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
-	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.CreateTransaction", params, nil)
-	ctx.RunWithoutMarshal()
+	commands.CreateAssetTransfer(cmd, args, tokenty.TokenX)
 }
 
 // CreateTokenTransferExecCmd create raw transfer tx
@@ -124,41 +100,7 @@ func addCreateTokenSendToExecFlags(cmd *cobra.Command) {
 }
 
 func createTokenSendToExec(cmd *cobra.Command, args []string) {
-	paraName, _ := cmd.Flags().GetString("paraName")
-	exec, _ := cmd.Flags().GetString("exec")
-	exec = getRealExecName(paraName, exec)
-	to, err := GetExecAddr(exec)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-
-	amount, _ := cmd.Flags().GetFloat64("amount")
-	note, _ := cmd.Flags().GetString("note")
-	symbol, _ := cmd.Flags().GetString("symbol")
-
-	payload := &types.AssetsTransferToExec{
-		To:        to,
-		Amount:    int64(math.Trunc((amount+0.0000001)*1e4)) * 1e4,
-		Note:      []byte(note),
-		Cointoken: symbol,
-		ExecName:  exec,
-	}
-
-	data, err := json.Marshal(&payload)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	params := &rpctypes.CreateTxIn{
-		Execer:     types.ExecName(tokenty.TokenX),
-		ActionName: "TransferToExec",
-		Payload:    data,
-	}
-
-	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
-	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.CreateTransaction", params, nil)
-	ctx.RunWithoutMarshal()
+	commands.CreateAssetSendToExec(cmd, args, tokenty.TokenX)
 }
 
 // CreateTokenWithdrawCmd create raw withdraw tx
@@ -186,40 +128,7 @@ func addCreateTokenWithdrawFlags(cmd *cobra.Command) {
 }
 
 func createTokenWithdraw(cmd *cobra.Command, args []string) {
-	exec, _ := cmd.Flags().GetString("exec")
-	paraName, _ := cmd.Flags().GetString("paraName")
-	exec = getRealExecName(paraName, exec)
-	amount, _ := cmd.Flags().GetFloat64("amount")
-	note, _ := cmd.Flags().GetString("note")
-	symbol, _ := cmd.Flags().GetString("symbol")
-
-	exec = getRealExecName(paraName, exec)
-	execAddr, err := GetExecAddr(exec)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	payload := &types.AssetsWithdraw{
-		To:        execAddr,
-		Amount:    int64(math.Trunc((amount+0.0000001)*1e4)) * 1e4,
-		Note:      []byte(note),
-		Cointoken: symbol,
-		ExecName:  exec,
-	}
-	data, err := json.Marshal(&payload)
-	if err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		return
-	}
-	params := &rpctypes.CreateTxIn{
-		Execer:     types.ExecName(tokenty.TokenX),
-		ActionName: "Withdraw",
-		Payload:    data,
-	}
-
-	rpcLaddr, _ := cmd.Flags().GetString("rpc_laddr")
-	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Chain33.CreateTransaction", params, nil)
-	ctx.RunWithoutMarshal()
+	commands.CreateAssetWithdraw(cmd, args, tokenty.TokenX)
 }
 
 // GetTokensPreCreatedCmd get precreated tokens


### PR DESCRIPTION
paracross, token 的命令行资产命令实现， 统一调用commands.asset.go， 不再需要重复实现。 原paracross  send to exec 命令bug， 间接被修复
close #190 