### PR TITLE
fix_cli_status

### DIFF
--- a/plugin/dapp/retrieve/types/const.go
+++ b/plugin/dapp/retrieve/types/const.go
@@ -8,9 +8,9 @@ import "github.com/33cn/chain33/types"
 
 //retrieve
 const (
-	RetrievePreapre = iota + 1
+	RetrieveBackup = iota + 1
+	RetrievePreapre
 	RetrievePerform
-	RetrieveBackup
 	RetrieveCancel
 )
 


### PR DESCRIPTION
修改用于CLI显示状态的枚举值，使其与操作的状态枚举值一致