### PR TITLE
Fix trade exec error type

### DIFF
--- a/plugin/dapp/trade/commands/trade.go
+++ b/plugin/dapp/trade/commands/trade.go
@@ -81,7 +81,7 @@ func showOnesSellOrders(cmd *cobra.Command, args []string) {
 		FuncName: "GetOnesSellOrder",
 		Payload:  types.MustPBToJSON(&reqAddrtokens),
 	}
-	var res pty.ReplySellOrders
+	var res pty.ReplyTradeOrders
 	ctx := jsonrpc.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.SetResultCb(parseSellOrders)
 	ctx.Run()
@@ -122,7 +122,7 @@ func showOnesSellOrdersStatus(cmd *cobra.Command, args []string) {
 	params.Execer = "trade"
 	params.FuncName = "GetOnesSellOrderWithStatus"
 	params.Payload = types.MustPBToJSON(&reqAddrtokens)
-	var res pty.ReplySellOrders
+	var res pty.ReplyTradeOrders
 	ctx := jsonrpc.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.SetResultCb(parseSellOrders)
 	ctx.Run()
@@ -175,7 +175,7 @@ func showTokenSellOrdersStatus(cmd *cobra.Command, args []string) {
 	params.Execer = "trade"
 	params.FuncName = "GetTokenSellOrderByStatus"
 	params.Payload = types.MustPBToJSON(&req)
-	var res pty.ReplySellOrders
+	var res pty.ReplyTradeOrders
 	ctx := jsonrpc.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.SetResultCb(parseSellOrders)
 	ctx.Run()
@@ -238,7 +238,7 @@ func showOnesBuyOrders(cmd *cobra.Command, args []string) {
 	params.Execer = "trade"
 	params.FuncName = "GetOnesBuyOrder"
 	params.Payload = types.MustPBToJSON(&reqAddrtokens)
-	var res pty.ReplyBuyOrders
+	var res pty.ReplyTradeOrders
 	ctx := jsonrpc.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.SetResultCb(parseBuyOrders)
 	ctx.Run()
@@ -278,7 +278,7 @@ func showOnesBuyOrdersStatus(cmd *cobra.Command, args []string) {
 	params.Execer = "trade"
 	params.FuncName = "GetOnesBuyOrderWithStatus"
 	params.Payload = types.MustPBToJSON(&reqAddrtokens)
-	var res pty.ReplyBuyOrders
+	var res pty.ReplyTradeOrders
 	ctx := jsonrpc.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.SetResultCb(parseBuyOrders)
 	ctx.Run()
@@ -331,7 +331,7 @@ func showTokenBuyOrdersStatus(cmd *cobra.Command, args []string) {
 	params.Execer = "trade"
 	params.FuncName = "GetTokenBuyOrderByStatus"
 	params.Payload = types.MustPBToJSON(&req)
-	var res pty.ReplyBuyOrders
+	var res pty.ReplyTradeOrders
 	ctx := jsonrpc.NewRPCCtx(rpcLaddr, "Chain33.Query", params, &res)
 	ctx.SetResultCb(parseBuyOrders)
 	ctx.Run()

--- a/plugin/dapp/trade/executor/tradedb.go
+++ b/plugin/dapp/trade/executor/tradedb.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/33cn/chain33/account"
 	"github.com/33cn/chain33/client"
@@ -17,7 +18,6 @@ import (
 	"github.com/33cn/chain33/system/dapp"
 	"github.com/33cn/chain33/types"
 	pty "github.com/33cn/plugin/plugin/dapp/trade/types"
-	"strings"
 )
 
 type sellDB struct {


### PR DESCRIPTION
在sell_market时， 输入的应该是买单的id。 输入卖单的id， 原本预期报 id 不存在的。 实际 id 存在但不是买单。  这种情况下预期是pb解码成卖单时出错， 报id不存在的错误。 

实际上， 由于买单和卖单的pb结果的原因， 解码没有报错， 但各个域错位， 解码出来的结构体没实际意义， 后续作为构造帐号的参数， 导致报 ErrExecNameNotAllow 。 

现在增加检测输入id前缀， 不满足直接报 ErrInvalidParam