### PR TITLE
fix exec error: check input sell/buy id

### DIFF
--- a/plugin/dapp/trade/executor/tradedb.go
+++ b/plugin/dapp/trade/executor/tradedb.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/33cn/chain33/account"
 	"github.com/33cn/chain33/client"
@@ -305,7 +306,7 @@ func (action *tradeAction) tradeSell(sell *pty.TradeForSell) (*types.Receipt, er
 }
 
 func (action *tradeAction) tradeBuy(buyOrder *pty.TradeForBuy) (*types.Receipt, error) {
-	if buyOrder.BoardlotCnt < 0 {
+	if buyOrder.BoardlotCnt < 0 || !strings.HasPrefix(buyOrder.SellID, sellIDPrefix) {
 		return nil, types.ErrInvalidParam
 	}
 
@@ -375,6 +376,9 @@ func (action *tradeAction) tradeBuy(buyOrder *pty.TradeForBuy) (*types.Receipt, 
 }
 
 func (action *tradeAction) tradeRevokeSell(revoke *pty.TradeForRevokeSell) (*types.Receipt, error) {
+	if !strings.HasPrefix(revoke.SellID, sellIDPrefix) {
+		return nil, types.ErrInvalidParam
+	}
 	sellidByte := []byte(revoke.SellID)
 	sellOrder, err := getSellOrderFromID(sellidByte, action.db)
 	if err != nil {
@@ -486,13 +490,14 @@ func (action *tradeAction) tradeBuyLimit(buy *pty.TradeForBuyLimit) (*types.Rece
 }
 
 func (action *tradeAction) tradeSellMarket(sellOrder *pty.TradeForSellMarket) (*types.Receipt, error) {
-	if sellOrder.BoardlotCnt < 0 {
+	if sellOrder.BoardlotCnt < 0 || !strings.HasPrefix(sellOrder.BuyID, buyIDPrefix) {
 		return nil, types.ErrInvalidParam
 	}
 
 	idByte := []byte(sellOrder.BuyID)
 	buyOrder, err := getBuyOrderFromID(idByte, action.db)
 	if err != nil {
+		tradelog.Error("getBuyOrderFromID failed", "err", err)
 		return nil, pty.ErrTBuyOrderNotExist
 	}
 
@@ -509,6 +514,7 @@ func (action *tradeAction) tradeSellMarket(sellOrder *pty.TradeForSellMarket) (*
 	// 打token
 	accDB, err := createAccountDB(action.height, action.db, buyOrder.AssetExec, buyOrder.TokenSymbol)
 	if err != nil {
+		tradelog.Error("createAccountDB failed", "err", err, "order", buyOrder)
 		return nil, err
 	}
 	amountToken := sellOrder.BoardlotCnt * buyOrder.AmountPerBoardlot
@@ -556,6 +562,9 @@ func (action *tradeAction) tradeSellMarket(sellOrder *pty.TradeForSellMarket) (*
 }
 
 func (action *tradeAction) tradeRevokeBuyLimit(revoke *pty.TradeForRevokeBuy) (*types.Receipt, error) {
+	if !strings.HasPrefix(revoke.BuyID, buyIDPrefix) {
+		return nil, types.ErrInvalidParam
+	}
 	buyIDByte := []byte(revoke.BuyID)
 	buyOrder, err := getBuyOrderFromID(buyIDByte, action.db)
 	if err != nil {


### PR DESCRIPTION
在sell_market时， 输入的应该是买单的id。 输入卖单的id， 原本预期报 id 不存在的。 实际 id 存在但不是买单。 这种情况下预期是pb解码成卖单时出错， 报id不存在的错误。

实际上， 由于买单和卖单的pb结果的原因， 解码没有报错， 但各个域错位， 解码出来的结构体没实际意义， 后续作为构造帐号的参数， 导致报 ErrExecNameNotAllow 。

现在增加检测输入id前缀， 不满足直接报 ErrInvalidParam