### PR TITLE
Js creator

### DIFF
--- a/plugin/dapp/js/autotest/case.go
+++ b/plugin/dapp/js/autotest/case.go
@@ -1,0 +1,24 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package autotest
+
+import (
+	"github.com/33cn/chain33/cmd/autotest/types"
+)
+
+// JsCreateCase token createcase command
+type JsCreateCase struct {
+	types.BaseCase
+}
+
+// JsCreatePack defines  create package command
+type JsCreatePack struct {
+	types.BaseCasePack
+}
+
+// SendCommand defines send command function of tokenprecreatecase
+func (testCase *JsCreateCase) SendCommand(packID string) (types.PackFunc, error) {
+	return types.DefaultSend(testCase, &JsCreatePack{}, packID)
+}

--- a/plugin/dapp/js/autotest/js.go
+++ b/plugin/dapp/js/autotest/js.go
@@ -1,0 +1,28 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package autotest
+
+import (
+	"reflect"
+
+	"github.com/33cn/chain33/cmd/autotest/types"
+)
+
+type jsAutoTest struct {
+	SimpleCaseArr   []types.SimpleCase `toml:"SimpleCase,omitempty"`
+	JSCreateCaseArr []JsCreateCase     `toml:"jsCreateCase,omitempty"`
+}
+
+func init() {
+	types.RegisterAutoTest(jsAutoTest{})
+}
+
+func (config jsAutoTest) GetName() string {
+	return "js"
+}
+
+func (config jsAutoTest) GetTestConfigType() reflect.Type {
+	return reflect.TypeOf(config)
+}

--- a/plugin/dapp/js/autotest/js.toml
+++ b/plugin/dapp/js/autotest/js.toml
@@ -1,0 +1,18 @@
+
+# 1Q8hGLfoGe63efeWa8fJ4Pnukhkngt6poK manage addr
+# 0xc34b5d9d44ac7b754806f761d3d4d2c4fe5214f6b074c19f069c4f5c2a29c8cc
+
+[[jsCreateCase]]
+id = "create1"
+command = "send  jsvm  create -c ../../../plugin/dapp/js/executor/game.js -n hello -k 14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
+fail = true
+
+[[jsCreateCase]]
+id = "create2"
+command = "send  jsvm  create -c ../../../plugin/dapp/js/executor/game.js -n hello -k 14KEKbYtKKQm4wMthSK9J4La4nAiidGozt"
+dep = ["create1", "configJS"]
+
+[[SimpleCase]]
+id = "configJS"
+dep = ["create1"]
+command = "send config  config_tx  -c js-creator -o add -v 14KEKbYtKKQm4wMthSK9J4La4nAiidGozt  -k 0xc34b5d9d44ac7b754806f761d3d4d2c4fe5214f6b074c19f069c4f5c2a29c8cc"

--- a/plugin/dapp/js/executor/creator.go
+++ b/plugin/dapp/js/executor/creator.go
@@ -1,3 +1,7 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
 package executor
 
 import (

--- a/plugin/dapp/js/executor/creator.go
+++ b/plugin/dapp/js/executor/creator.go
@@ -1,0 +1,37 @@
+package executor
+
+import (
+	dbm "github.com/33cn/chain33/common/db"
+	"github.com/33cn/chain33/types"
+
+	ptypes "github.com/33cn/plugin/plugin/dapp/js/types"
+)
+
+func getManageKey(key string, db dbm.KV) ([]byte, error) {
+	manageKey := types.ManageKey(key)
+	return db.Get([]byte(manageKey))
+}
+
+func checkPriv(addr, key string, db dbm.KV) error {
+	value, err := getManageKey(key, db)
+	if err != nil {
+		return err
+	}
+	if value == nil {
+		return ptypes.ErrJsCreator
+	}
+
+	var item types.ConfigItem
+	err = types.Decode(value, &item)
+	if err != nil {
+		return err
+	}
+
+	for _, op := range item.GetArr().Value {
+		if op == addr {
+			return nil
+		}
+	}
+
+	return ptypes.ErrJsCreator
+}

--- a/plugin/dapp/js/executor/exec.go
+++ b/plugin/dapp/js/executor/exec.go
@@ -8,13 +8,18 @@ import (
 )
 
 func (c *js) Exec_Create(payload *jsproto.Create, tx *types.Transaction, index int) (*types.Receipt, error) {
+	err := checkPriv(tx.From(), ptypes.JsCreator, c.GetStateDB())
+	if err != nil {
+		return nil, err
+	}
+
 	execer := types.ExecName("user." + ptypes.JsX + "." + payload.Name)
 	if string(tx.Execer) != ptypes.JsX {
 		return nil, types.ErrExecNameNotMatch
 	}
 	c.prefix = calcStatePrefix([]byte(execer))
 	kvc := dapp.NewKVCreator(c.GetStateDB(), c.prefix, nil)
-	_, err := kvc.GetNoPrefix(calcCodeKey(payload.Name))
+	_, err = kvc.GetNoPrefix(calcCodeKey(payload.Name))
 	if err != nil && err != types.ErrNotFound {
 		return nil, err
 	}

--- a/plugin/dapp/js/executor/jsvm_test.go
+++ b/plugin/dapp/js/executor/jsvm_test.go
@@ -37,6 +37,16 @@ func initExec(ldb db.DB, kvdb db.KVDB, code string, t assert.TestingT) *js {
 	e.SetLocalDB(kvdb)
 	e.SetStateDB(kvdb)
 	c, tx := createCodeTx("test", code)
+	// set config key
+	item := &types.ConfigItem{
+		Key:  "mavl-manage-js-creator",
+		Addr: tx.From(),
+		Value: &types.ConfigItem_Arr{
+			Arr: &types.ArrayConfig{Value: []string{tx.From()}},
+		},
+	}
+	kvdb.Set([]byte(item.Key), types.Encode(item))
+
 	receipt, err := e.Exec_Create(c, tx, 0)
 	assert.Nil(t, err)
 	util.SaveKVList(ldb, receipt.KV)

--- a/plugin/dapp/js/executor/jsvm_test.go
+++ b/plugin/dapp/js/executor/jsvm_test.go
@@ -37,6 +37,7 @@ func initExec(ldb db.DB, kvdb db.KVDB, code string, t assert.TestingT) *js {
 	e.SetLocalDB(kvdb)
 	e.SetStateDB(kvdb)
 	c, tx := createCodeTx("test", code)
+
 	// set config key
 	item := &types.ConfigItem{
 		Key:  "mavl-manage-js-creator",

--- a/plugin/dapp/js/plugin.go
+++ b/plugin/dapp/js/plugin.go
@@ -5,6 +5,9 @@ import (
 	"github.com/33cn/plugin/plugin/dapp/js/cmd"
 	"github.com/33cn/plugin/plugin/dapp/js/executor"
 	ptypes "github.com/33cn/plugin/plugin/dapp/js/types"
+
+	// init auto test
+	_ "github.com/33cn/plugin/plugin/dapp/js/autotest"
 )
 
 func init() {

--- a/plugin/dapp/js/types/js.go
+++ b/plugin/dapp/js/types/js.go
@@ -19,6 +19,9 @@ const (
 	TyLogJs = 10000
 )
 
+// JsCreator 配置项 创建js合约的管理员
+const JsCreator = "js-creator"
+
 var (
 	typeMap = map[string]int32{
 		"Create": jsActionCreate,
@@ -47,6 +50,8 @@ var (
 	ErrSymbolName   = errors.New("chain33.js: ErrSymbolName")
 	ErrExecerName   = errors.New("chain33.js: ErrExecerName")
 	ErrDBType       = errors.New("chain33.js: ErrDBType")
+	// ErrJsCreator
+	ErrJsCreator = errors.New("ErrJsCreator")
 )
 
 func init() {


### PR DESCRIPTION
1.  增加 js 合约需要管理员权限。 管理员由manager 合约控制， 对应的key 为 "js-creator"
1. 增加 js 合约的 auto test

close https://github.com/33cn/chain33/issues/315