### PR TITLE
fix token logs: token finish create 的hash 缺少0x前缀

### DIFF
--- a/plugin/dapp/token/doc.go
+++ b/plugin/dapp/token/doc.go
@@ -6,6 +6,7 @@
 //主要包含两方面功能
 // 1. token 的创建
 // 1. token 的转账
+// 1. token 燃烧和增发
 //
 //token的创建
 // 1. prepare create

--- a/plugin/dapp/token/executor/exec_local.go
+++ b/plugin/dapp/token/executor/exec_local.go
@@ -113,7 +113,7 @@ func (t *token) ExecLocal_TokenFinishCreate(payload *tokenty.TokenFinishCreate, 
 
 	table := NewLogsTable(t.GetLocalDB())
 	txIndex := dapp.HeightIndexStr(t.GetHeight(), int64(index))
-	err = table.Add(&tokenty.LocalLogs{Symbol: payload.Symbol, TxIndex: txIndex, ActionType: tokenty.TokenActionFinishCreate, TxHash: hex.EncodeToString(tx.Hash())})
+	err = table.Add(&tokenty.LocalLogs{Symbol: payload.Symbol, TxIndex: txIndex, ActionType: tokenty.TokenActionFinishCreate, TxHash: "0x" + hex.EncodeToString(tx.Hash())})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
fix
```
$ ./build/chain33-cli  token get_token_logs  -s TC
{
    "logs": [
        {
            "symbol": "TC",
            "txIndex": "000000000002300000",
            "actionType": 13,
            "txHash": "0xa288cc1c9b265ee3ddaf75630282c14a9461c4e97715014eb32d33e94b4f7636"
        },
        {
            "symbol": "TC",
            "txIndex": "000000000002000000",
            "actionType": 12,
            "txHash": "0x28d2be9acd00f473cb29cc77fb85ca14305d35089a446dcc7dadf4fd8c13757f"
        },
        {
            "symbol": "TC",
            "txIndex": "000000000000800000",
            "actionType": 8,
            "txHash": "0x0f7419ef74cd75715e860d5fe1421b3fda37766d35af87a59882ce0a1ea1cb95"
        }
    ]
}
```