### PR TITLE
Para wallet

### DIFF
--- a/plugin/consensus/para/para.go
+++ b/plugin/consensus/para/para.go
@@ -845,3 +845,19 @@ func checkMinerTx(current *types.BlockDetail) error {
 	}
 	return nil
 }
+
+// Query_CreateNewAccount 通知para共识模块钱包创建了一个新的账户
+func (client *client) Query_CreateNewAccount(acc *types.Account) (types.Message, error) {
+	plog.Info("Query_CreateNewAccount", "acc", acc)
+	// 需要para共识这边处理新创建的账户是否是超级节点发送commit共识交易的账户
+	// 需要实现具体处理 to be。。。。
+	return &types.Reply{IsOk: true, Msg: []byte("OK")}, nil
+}
+
+// Query_WalletStatus 通知para共识模块钱包锁状态有变化
+func (client *client) Query_WalletStatus(walletStatus *types.WalletStatus) (types.Message, error) {
+	plog.Info("Query_WalletStatus", "walletStatus", walletStatus)
+	// 需要para共识这边根据walletStatus.IsWalletLock锁的状态开启/关闭发送共识交易
+	// 需要实现具体处理 to be。。。。
+	return &types.Reply{IsOk: true, Msg: []byte("OK")}, nil
+}

--- a/plugin/consensus/para/paranode_test.go
+++ b/plugin/consensus/para/paranode_test.go
@@ -55,5 +55,38 @@ func TestParaNode(t *testing.T) {
 		para.Para.SendTxRPC(tx)
 		para.Para.WaitHeight(int64(i) + 1)
 	}
+}
+
+func TestParaQuery(t *testing.T) {
+	para := node.NewParaNode(nil, nil)
+	defer para.Close()
+
+	var param types.ReqWalletImportPrivkey
+	param.Label = "Importprivkey"
+	param.Privkey = "CC38546E9E659D15E6B4893F0AB32A06D103931A8230B0BDE71459D2B27D6944"
+	para.Para.GetAPI().Notify(
+		"consensus", types.EventConsensusQuery, &types.ChainExecutor{
+			Driver:   "para",
+			FuncName: "CreateNewAccount",
+			Param:    types.Encode(&param),
+		})
+
+	var param1 types.ReqNewAccount
+	param1.Label = "NewAccount"
+	para.Para.GetAPI().Notify(
+		"consensus", types.EventConsensusQuery, &types.ChainExecutor{
+			Driver:   "para",
+			FuncName: "CreateNewAccount",
+			Param:    types.Encode(&param1),
+		})
+
+	var walletsatus types.WalletStatus
+	walletsatus.IsWalletLock = true
+	para.Para.GetAPI().Notify(
+		"consensus", types.EventConsensusQuery, &types.ChainExecutor{
+			Driver:   "para",
+			FuncName: "WalletStatus",
+			Param:    types.Encode(&walletsatus),
+		})
 
 }

--- a/plugin/consensus/para/paranode_test.go
+++ b/plugin/consensus/para/paranode_test.go
@@ -55,11 +55,10 @@ func TestParaNode(t *testing.T) {
 		para.Para.SendTxRPC(tx)
 		para.Para.WaitHeight(int64(i) + 1)
 	}
+	testParaQuery(para)
 }
 
-func TestParaQuery(t *testing.T) {
-	para := node.NewParaNode(nil, nil)
-	defer para.Close()
+func testParaQuery(para *node.ParaNode) {
 
 	var param types.ReqWalletImportPrivkey
 	param.Label = "Importprivkey"

--- a/plugin/dapp/paracross/plugin.go
+++ b/plugin/dapp/paracross/plugin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/33cn/plugin/plugin/dapp/paracross/executor"
 	"github.com/33cn/plugin/plugin/dapp/paracross/rpc"
 	"github.com/33cn/plugin/plugin/dapp/paracross/types"
+	_ "github.com/33cn/plugin/plugin/dapp/paracross/wallet" // register wallet package
 )
 
 func init() {

--- a/plugin/dapp/paracross/wallet/para.go
+++ b/plugin/dapp/paracross/wallet/para.go
@@ -31,6 +31,7 @@ func New() wcom.WalletBizPolicy {
 	return &ParaPolicy{mtx: &sync.Mutex{}}
 }
 
+// ParaPolicy: 结构体
 type ParaPolicy struct {
 	mtx           *sync.Mutex
 	walletOperate wcom.WalletOperate

--- a/plugin/dapp/paracross/wallet/para.go
+++ b/plugin/dapp/paracross/wallet/para.go
@@ -1,0 +1,194 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package wallet
+
+import (
+	"sync"
+	"time"
+
+	"github.com/33cn/chain33/client"
+	"github.com/33cn/chain33/common/address"
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/33cn/chain33/common/db"
+	"github.com/33cn/chain33/common/log/log15"
+	"github.com/33cn/chain33/types"
+	wcom "github.com/33cn/chain33/wallet/common"
+	ty "github.com/33cn/plugin/plugin/dapp/paracross/types"
+)
+
+var (
+	bizlog = log15.New("module", "wallet.paracross")
+)
+
+func init() {
+	wcom.RegisterPolicy(ty.ParaX, New())
+}
+
+// New new instance
+func New() wcom.WalletBizPolicy {
+	return &ParaPolicy{mtx: &sync.Mutex{}}
+}
+
+type ParaPolicy struct {
+	mtx           *sync.Mutex
+	walletOperate wcom.WalletOperate
+	minertimeout  *time.Timer
+}
+
+func (policy *ParaPolicy) setWalletOperate(walletBiz wcom.WalletOperate) {
+	policy.mtx.Lock()
+	defer policy.mtx.Unlock()
+	policy.walletOperate = walletBiz
+}
+
+func (policy *ParaPolicy) getWalletOperate() wcom.WalletOperate {
+	policy.mtx.Lock()
+	defer policy.mtx.Unlock()
+	return policy.walletOperate
+}
+
+func (policy *ParaPolicy) getAPI() client.QueueProtocolAPI {
+	policy.mtx.Lock()
+	defer policy.mtx.Unlock()
+	return policy.walletOperate.GetAPI()
+}
+
+// Init initial
+func (policy *ParaPolicy) Init(walletBiz wcom.WalletOperate, sub []byte) {
+	policy.setWalletOperate(walletBiz)
+}
+
+// OnWalletLocked process lock event
+func (policy *ParaPolicy) OnWalletLocked() {
+	var walletsatus types.WalletStatus
+	wallet := policy.getWalletOperate()
+	walletsatus.IsWalletLock = wallet.IsWalletLocked()
+	NotifyConsensus(policy.getAPI(), "WalletStatus", types.Encode(&walletsatus))
+	bizlog.Info("OnWalletLocked", "IsWalletLock", walletsatus.IsWalletLock)
+}
+
+//解锁超时处理，需要区分整个钱包的解锁或者只挖矿的解锁
+func (policy *ParaPolicy) resetTimeout(Timeout int64) {
+	if policy.minertimeout == nil {
+		policy.minertimeout = time.AfterFunc(time.Second*time.Duration(Timeout), func() {
+			var walletsatus types.WalletStatus
+			wallet := policy.getWalletOperate()
+			walletsatus.IsWalletLock = wallet.IsWalletLocked()
+			NotifyConsensus(policy.getAPI(), "WalletStatus", types.Encode(&walletsatus))
+			bizlog.Info("resetTimeout", "IsWalletLock", walletsatus.IsWalletLock)
+		})
+	} else {
+		policy.minertimeout.Reset(time.Second * time.Duration(Timeout))
+	}
+}
+
+// OnWalletUnlocked process unlock event,只处理wallet锁
+func (policy *ParaPolicy) OnWalletUnlocked(param *types.WalletUnLock) {
+	if !param.WalletOrTicket {
+		if param.Timeout != 0 {
+			policy.resetTimeout(param.Timeout)
+		}
+		var walletsatus types.WalletStatus
+		wallet := policy.getWalletOperate()
+		walletsatus.IsWalletLock = wallet.IsWalletLocked()
+		NotifyConsensus(policy.getAPI(), "WalletStatus", types.Encode(&walletsatus))
+		bizlog.Info("OnWalletUnlocked", "IsWalletLock", walletsatus.IsWalletLock)
+	}
+
+}
+
+// OnCreateNewAccount 通知para共识有新账户创建
+func (policy *ParaPolicy) OnCreateNewAccount(acc *types.Account) {
+	NotifyConsensus(policy.getAPI(), "CreateNewAccount", types.Encode(acc))
+	bizlog.Info("OnCreateNewAccount", "Addr", acc.Addr)
+}
+
+// OnImportPrivateKey 通知para共识有新账户导入
+func (policy *ParaPolicy) OnImportPrivateKey(acc *types.Account) {
+	NotifyConsensus(policy.getAPI(), "CreateNewAccount", types.Encode(acc))
+	bizlog.Info("OnImportPrivateKey", "Addr", acc.Addr)
+}
+
+// NotifyConsensus 通知para共识模块做相应的处理
+func NotifyConsensus(api client.QueueProtocolAPI, FuncName string, param []byte) {
+	bizlog.Info("Wallet Notify Consensus")
+	api.Notify("consensus", types.EventConsensusQuery, &types.ChainExecutor{
+		Driver:   "para",
+		FuncName: FuncName,
+		Param:    param,
+	})
+}
+
+// OnClose close
+func (policy *ParaPolicy) OnClose() {
+}
+
+// OnSetQueueClient on set queue client
+func (policy *ParaPolicy) OnSetQueueClient() {
+}
+
+// Call call
+func (policy *ParaPolicy) Call(funName string, in types.Message) (ret types.Message, err error) {
+	err = types.ErrNotSupport
+	return
+}
+
+// OnAddBlockTx add Block tx
+func (policy *ParaPolicy) OnAddBlockTx(block *types.BlockDetail, tx *types.Transaction, index int32, dbbatch db.Batch) *types.WalletTxDetail {
+	return policy.proceWalletTxDetail(block, tx, index)
+}
+
+// OnDeleteBlockTx on delete block
+func (policy *ParaPolicy) OnDeleteBlockTx(block *types.BlockDetail, tx *types.Transaction, index int32, dbbatch db.Batch) *types.WalletTxDetail {
+	return policy.proceWalletTxDetail(block, tx, index)
+}
+
+// SignTransaction sign tx
+func (policy *ParaPolicy) SignTransaction(key crypto.PrivKey, req *types.ReqSignRawTx) (needSysSign bool, signtx string, err error) {
+	needSysSign = true
+	return
+}
+
+// OnAddBlockFinish process finish block
+func (policy *ParaPolicy) OnAddBlockFinish(block *types.BlockDetail) {
+}
+
+// OnDeleteBlockFinish process finish block
+func (policy *ParaPolicy) OnDeleteBlockFinish(block *types.BlockDetail) {
+}
+
+func (policy *ParaPolicy) proceWalletTxDetail(block *types.BlockDetail, tx *types.Transaction, index int32) *types.WalletTxDetail {
+	receipt := block.Receipts[index]
+	amount, err := tx.Amount()
+	if err != nil {
+		bizlog.Error("proceWalletTxDetail:tx.Amount()", "err", err)
+	}
+	wtxdetail := &types.WalletTxDetail{
+		Tx:         tx,
+		Height:     block.Block.Height,
+		Index:      int64(index),
+		Receipt:    receipt,
+		Blocktime:  block.Block.BlockTime,
+		ActionName: tx.ActionName(),
+		Amount:     amount,
+		Payload:    nil,
+	}
+	if len(wtxdetail.Fromaddr) <= 0 {
+		pubkey := tx.Signature.GetPubkey()
+		address := address.PubKeyToAddress(pubkey)
+		//from addr
+		fromaddress := address.String()
+		if len(fromaddress) != 0 && policy.walletOperate.AddrInWallet(fromaddress) {
+			wtxdetail.Fromaddr = fromaddress
+		}
+	}
+	if len(wtxdetail.Fromaddr) <= 0 {
+		toaddr := tx.GetTo()
+		if len(toaddr) != 0 && policy.walletOperate.AddrInWallet(toaddr) {
+			wtxdetail.Fromaddr = toaddr
+		}
+	}
+	return wtxdetail
+}

--- a/plugin/dapp/paracross/wallet/para.go
+++ b/plugin/dapp/paracross/wallet/para.go
@@ -31,7 +31,7 @@ func New() wcom.WalletBizPolicy {
 	return &ParaPolicy{mtx: &sync.Mutex{}}
 }
 
-// ParaPolicy: 结构体
+// ParaPolicy 结构体
 type ParaPolicy struct {
 	mtx           *sync.Mutex
 	walletOperate wcom.WalletOperate

--- a/plugin/dapp/paracross/wallet/para_test.go
+++ b/plugin/dapp/paracross/wallet/para_test.go
@@ -1,0 +1,41 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package wallet_test
+
+import (
+	"testing"
+
+	"github.com/33cn/chain33/util"
+
+	_ "github.com/33cn/chain33/system"
+	"github.com/33cn/chain33/types"
+	_ "github.com/33cn/plugin/plugin"
+	node "github.com/33cn/plugin/plugin/dapp/paracross/testnode"
+)
+
+func TestParaQuery(t *testing.T) {
+	para := node.NewParaNode(nil, nil)
+	defer para.Close()
+
+	var param types.ReqWalletImportPrivkey
+	param.Label = "Importprivkey"
+	param.Privkey = "CC38546E9E659D15E6B4893F0AB32A06D103931A8230B0BDE71459D2B27D6944"
+	para.Para.GetAPI().WalletImportprivkey(&param)
+
+	var param1 types.ReqNewAccount
+	param1.Label = "NewAccount"
+	para.Para.GetAPI().NewAccount(&param1)
+
+	para.Para.GetAPI().WalletLock()
+
+	//通过rpc 发生信息
+	tx := util.CreateTxWithExecer(para.Para.GetGenesisKey(), "user.p.guodun.none")
+	para.Para.SendTxRPC(tx)
+	para.Para.WaitHeight(1)
+	tx = util.CreateTxWithExecer(para.Para.GetGenesisKey(), "user.p.guodun.none")
+	para.Para.SendTxRPC(tx)
+	para.Para.WaitHeight(2)
+
+}


### PR DESCRIPTION
paracross合约增加一个wallet插件，监听wallet的lock，unlock，newaccount和importPrivateKey 事件，及时通知para共识模块做相应的处理。

钱包锁状态的更新及时通知para共识开启或者停止挖矿

在para共识模块没有获取到挖矿地址的私钥时，通过newaccount和importPrivateKey 事件通知para模块，新创建的账户是否是挖矿账户。