### PR TITLE
fix token balance 

### DIFF
--- a/plugin/dapp/token/rpc/rpc.go
+++ b/plugin/dapp/token/rpc/rpc.go
@@ -25,9 +25,7 @@ func (c *channelClient) getTokenBalance(in *tokenty.ReqTokenBalance) ([]*types.A
 	case types.ExecName(tokenty.TokenX):
 		addrs := in.GetAddresses()
 		var queryAddrs []string
-		for _, addr := range addrs {
-			queryAddrs = append(queryAddrs, addr)
-		}
+		queryAddrs = append(queryAddrs, addrs...)
 
 		accounts, err := accountTokendb.LoadAccounts(c.QueueProtocolAPI, queryAddrs)
 		if err != nil {

--- a/plugin/dapp/token/rpc/rpc.go
+++ b/plugin/dapp/token/rpc/rpc.go
@@ -26,9 +26,6 @@ func (c *channelClient) getTokenBalance(in *tokenty.ReqTokenBalance) ([]*types.A
 		addrs := in.GetAddresses()
 		var queryAddrs []string
 		for _, addr := range addrs {
-			if err := address.CheckAddress(addr); err != nil {
-				addr = string(accountTokendb.AccountKey(addr))
-			}
 			queryAddrs = append(queryAddrs, addr)
 		}
 


### PR DESCRIPTION
修复： 在错误地址输入时， addr会带上 mavl-token-MGT 返回

$ ./chain33-cli --rpc_laddr="http://localhost:9809" --paraName="user.p.guodun." token token_balance  -e user.p.guodun.token -s MGT -a 124DWRdRTFegK2yJjmuqS7e5wfvGi9PRBZXX
[
    {
        "Token": "MGT",
        "balance": "0.0000",
        "frozen": "0.0000",
        "addr": "mavl-token-MGT-124DWRdRTFegK2yJjmuqS7e5wfvGi9PRBZXX"
    }
]
linj@linj-TM1701:~/guodun$ ./chain33-cli --rpc_laddr="http://localhost:9809" --paraName="user.p.guodun." token token_balance  -e user.p.guodun.token -s MGT -a 124DWRdRTFegK2yJjmuqS7e5wfvGi9PRBZXX
[
    {
        "Token": "MGT",
        "balance": "0.0000",
        "frozen": "0.0000",
        "addr": "124DWRdRTFegK2yJjmuqS7e5wfvGi9PRBZXX"
    }
]