### PR TITLE
平行链共识交易重发

### DIFF
--- a/plugin/consensus/para/paracommitmsg.go
+++ b/plugin/consensus/para/paracommitmsg.go
@@ -9,6 +9,8 @@ import (
 	"context"
 	"time"
 
+	"strings"
+
 	"github.com/33cn/chain33/common"
 	"github.com/33cn/chain33/common/crypto"
 	"github.com/33cn/chain33/types"
@@ -23,31 +25,37 @@ var (
 )
 
 type commitMsgClient struct {
-	paraClient         *client
-	waitMainBlocks     int32
-	commitMsgNotify    chan int64
-	delMsgNotify       chan int64
-	mainBlockAdd       chan *types.BlockDetail
-	minerSwitch        chan bool
-	currentTx          *types.Transaction
-	checkTxCommitTimes int32
-	privateKey         crypto.PrivKey
-	quit               chan struct{}
+	paraClient           *client
+	waitMainBlocks       int32  //等待平行链共识消息在主链上链并成功的块数，超出会重发共识消息，最小是2
+	waitConsensStopTimes uint32 //共识高度低于完成高度， reset高度重发等待的次数
+	commitMsgNotify      chan int64
+	delMsgNotify         chan int64
+	mainBlockAdd         chan *types.BlockDetail
+	minerSwitch          chan bool
+	currentTx            *types.Transaction
+	checkTxCommitTimes   int32
+	privateKey           crypto.PrivKey
+	quit                 chan struct{}
+}
+
+type commitConsensRsp struct {
+	status        *pt.ParacrossStatus
+	authAccountIn bool //是否授权账户包含在node group addrs
 }
 
 func (client *commitMsgClient) handler() {
 	var isSync bool
 	var isRollback bool
 	var notification []int64 //记录每次系统重启后 min and current height
-	var finishHeight int64
-	var consensHeight int64
+	var finishHeight int64 = -1
 	var sendingHeight int64 //当前发送的最大高度
 	var sendingMsgs []*pt.ParacrossNodeStatus
 	var readTick <-chan time.Time
 	var ticker *time.Ticker
+	var consensTimes uint32
 
 	client.paraClient.wg.Add(1)
-	consensusCh := make(chan *pt.ParacrossStatus, 1)
+	consensusCh := make(chan *commitConsensRsp, 1)
 	go client.getConsensusHeight(consensusCh)
 
 	client.paraClient.wg.Add(1)
@@ -92,7 +100,6 @@ out:
 			if height <= finishHeight {
 				finishHeight = notification[0] - 1
 			}
-			isSync = false
 			isRollback = true
 			plog.Debug("para del block", "delHeight", height)
 
@@ -145,9 +152,9 @@ out:
 				client.checkTxCommitTimes = 0
 				sendMsgCh <- client.currentTx
 
-				plog.Info("paracommitmsg sending", "txhash", common.ToHex(signTx.Hash()), "exec", string(signTx.Execer))
+				plog.Debug("paracommitmsg sending", "txhash", common.ToHex(signTx.Hash()), "exec", string(signTx.Execer))
 				for i, msg := range sendingMsgs {
-					plog.Info("paracommitmsg sending", "idx", i, "height", msg.Height, "mainheight", msg.MainBlockHeight,
+					plog.Debug("paracommitmsg sending", "idx", i, "height", msg.Height, "mainheight", msg.MainBlockHeight,
 						"blockhash", common.HashHex(msg.BlockHash), "mainHash", common.HashHex(msg.MainBlockHash),
 						"from", client.paraClient.authAccount)
 				}
@@ -156,11 +163,13 @@ out:
 		//获取正在共识的高度，同步有两层意思，一个是主链跟其他节点完成了同步，另一个是当前平行链节点的高度追赶上了共识高度
 		//一般来说高度增长从小到大： notifiy[0] -- selfConsensusHeight(mainHeight) -- finishHeight -- sendingHeight -- notify[1]
 		case rsp := <-consensusCh:
-			consensHeight = rsp.Height
+			consensHeight := rsp.status.Height
 			plog.Info("para consensus rcv", "notify", notification, "sending", len(sendingMsgs),
-				"consensHeigt", rsp.Height, "finished", finishHeight, "sync", isSync, "miner", readTick != nil, "consensBlockHash", common.ToHex(rsp.BlockHash))
+				"consensHeight", rsp.status.Height, "finishHeight", finishHeight, "authIn", rsp.authAccountIn, "sync", isSync, "consensStopTimes", consensTimes, "miner", readTick != nil)
+			plog.Debug("para consensus rcv", "consensBlockHash", common.ToHex(rsp.status.BlockHash))
 
-			if notification == nil || isRollback {
+			if notification == nil || isRollback || !rsp.authAccountIn {
+				isSync = false
 				continue
 			}
 
@@ -169,31 +178,25 @@ out:
 				isSync = true
 			}
 
-			// 共识高度追赶上完成高度之后再发，不然分叉节点继续发浪费手续费
+			// 共识高度追赶上完成高度之后再发，不然继续发浪费手续费
 			if finishHeight > consensHeight {
-				isSync = false
+				if consensTimes < client.waitConsensStopTimes {
+					isSync = false
+					consensTimes++
+					continue
+				}
+
+				//reset finishHeight to consensHeight and resent
+				finishHeight = consensHeight
 			}
 
 			//未共识过的小于当前共识高度的区块，可以不参与共识, 如果是新节点，一直等到同步的区块达到了共识高度，才设置同步参与共识
 			//在某些特殊场景下，比如平行链连接的主链节点分叉后又恢复，主链的共识高度低于分叉高度时候，主链上形成共识空洞，需要从共识高度重新发送而不是分叉高度
 			//共识高度和分叉高度不一致其中一个原因是共识交易组里面某个高度分叉了，分叉的主链节点执行成功，而其他主链节点执行失败,共识高度停留在交易组最小高度-1
 			//而分叉高度是交易组里面的某个高度
-			if finishHeight < consensHeight {
+			if finishHeight <= consensHeight {
 				finishHeight = consensHeight
-				sendingMsgs = nil
-				client.currentTx = nil
-			}
-
-			//系统每次重启都有检查一次共识，如果共识高度落后于系统起来后完成的第一个高度或最小高度，说明可能有共识空洞，需要把从当前共识高度到完成的
-			//最大高度重发一遍，直到确认收到，发过的最小到最大高度也要重发是因为之前空洞原因共识不连续，即便满足2/3节点也不会增长，需要重发来触发commit
-			//此处也整合了当前consensus height=-1 场景
-			// 需要是<而不是<=, 因为notification[0]被认为是系统起来后已经发送过的
-			nextConsensHeight := consensHeight + 1
-			if nextConsensHeight < notification[0] {
-				notification[0] = nextConsensHeight
-				finishHeight = consensHeight
-				sendingMsgs = nil
-				client.currentTx = nil
+				consensTimes = 0
 			}
 
 		case miner := <-client.minerSwitch:
@@ -212,9 +215,6 @@ out:
 				ticker = time.NewTicker(time.Second * time.Duration(minerInterval))
 				readTick = ticker.C
 				plog.Info("para consensus start mining")
-
-				//钱包开启后，从共识高度重新开始发送，在需要重发共识时候，不需要重启设备
-				finishHeight = consensHeight
 			}
 
 		case <-client.quit:
@@ -511,7 +511,7 @@ func (client *commitMsgClient) mainSync() error {
 
 }
 
-func (client *commitMsgClient) getConsensusHeight(consensusRst chan *pt.ParacrossStatus) {
+func (client *commitMsgClient) getConsensusHeight(consensusRst chan *commitConsensRsp) {
 	ticker := time.NewTicker(time.Second * time.Duration(consensusInterval))
 	isSync := false
 	defer ticker.Stop()
@@ -547,7 +547,16 @@ out:
 			if err != nil {
 				continue
 			}
-			consensusRst <- status
+
+			authExist := false
+			if client.paraClient.authAccount != "" {
+				nodes, err := client.getNodeGroupAddrs()
+				if err != nil {
+					continue
+				}
+				authExist = strings.Contains(nodes, client.paraClient.authAccount)
+			}
+			consensusRst <- &commitConsensRsp{status: status, authAccountIn: authExist}
 		}
 	}
 
@@ -599,6 +608,26 @@ func (client *commitMsgClient) getConsensusStatus(block *types.Block) (*pt.Parac
 	}
 	return &result, nil
 
+}
+
+//node group会在主链和平行链都同时配置
+func (client *commitMsgClient) getNodeGroupAddrs() (string, error) {
+	ret, err := client.paraClient.GetAPI().QueryChain(&types.ChainExecutor{
+		Driver:   "paracross",
+		FuncName: "GetNodeGroupAddrs",
+		Param:    types.Encode(&pt.ReqParacrossNodeInfo{Title: types.GetTitle()}),
+	})
+	if err != nil {
+		plog.Error("commitmsg.getNodeGroupAddrs ", "err", err.Error())
+		return "", err
+	}
+	resp, ok := ret.(*types.ReplyConfig)
+	if !ok {
+		plog.Error("commitmsg.getNodeGroupAddrs rsp nok")
+		return "", err
+	}
+
+	return resp.Value, nil
 }
 
 func (client *commitMsgClient) onWalletStatus(status *types.WalletStatus) {

--- a/plugin/dapp/paracross/cmd/build/chain33.para.toml
+++ b/plugin/dapp/paracross/cmd/build/chain33.para.toml
@@ -1,6 +1,7 @@
-Title="user.p.guodun."
-# TestNet=true
-CoinSymbol="paracoin"
+Title="user.p.para."
+TestNet=false
+CoinSymbol="bty"
+EnableParaFork=true
 
 [log]
 # 日志级别，支持debug(dbug)/info/warn/error(eror)/crit
@@ -37,7 +38,9 @@ singleMode=true
 batchsync=false
 isRecordBlockSequence=false
 isParaChain = true
-enableTxQuickIndex=false
+enableTxQuickIndex=true
+# 升级storedb是否重新执行localdb，bityuan主链升级不需要开启，平行链升级需要开启
+enableReExecLocal=true
 
 [p2p]
 seeds=[]
@@ -56,9 +59,9 @@ grpcLogFile="grpc33.log"
 
 [rpc]
 # 避免与主链配置冲突
-jrpcBindAddr="localhost:8901"
-grpcBindAddr="localhost:8902"
-whitelist=["127.0.0.1"]
+jrpcBindAddr=":8901"
+grpcBindAddr=":8902"
+whitelist=["*"]
 jrpcFuncWhitelist=["*"]
 grpcFuncWhitelist=["*"]
 
@@ -92,6 +95,7 @@ targetTimePerBlock = 16
 
 [consensus.sub.para]
 #主链节点的grpc服务器ip，当前可以支持多ip负载均衡，如“101.37.227.226:8802,39.97.20.242:8802,47.107.15.126:8802,jiedian2.bityuan.com,cloud.bityuan.com”
+#ParaRemoteGrpcClient="101.37.227.226:8802,39.97.20.242:8802,47.107.15.126:8802,jiedian2.bityuan.com,cloud.bityuan.com"
 ParaRemoteGrpcClient="localhost:8802"
 #主链指定高度的区块开始同步
 startHeight=345850
@@ -101,26 +105,38 @@ writeBlockSeconds=2
 emptyBlockInterval=50
 #验证账户，验证节点需要配置自己的账户，并且钱包导入对应种子，非验证节点留空
 authAccount=""
-#等待平行链共识消息在主链上链并成功的块数，超出会重发共识消息，最小是2
-waitBlocks4CommitMsg=2
 #云端主链节点切换后，平行链适配新主链节点block，回溯查找和自己记录的相同blockhash的深度
 searchHashMatchedBlockDepth=10000
 #创世地址额度
 genesisAmount=100000000
-#主链支持平行链共识tx分叉高度，需要和主链保持严格一致
-MainForkParacrossCommitTx=-1
-#平行链自共识开启对应的主链高度，需要大于等于MainForkParacrossCommitTx
+#主链支持平行链共识tx分叉高度，需要和主链保持严格一致,不可修改
+MainForkParacrossCommitTx=2270000
+#平行链自共识开启对应的主链高度，需要大于等于MainForkParacrossCommitTx=2270000， -1 不开启
 MainParaSelfConsensusForkHeight=-1
 
 [store]
-name="mavl"
+name="kvmvccmavl"
 driver="leveldb"
+storedbVersion="2.0.0"
 dbPath="paradatadir/mavltree"
 dbCache=128
+
+[store.sub.mavl]
 enableMavlPrefix=false
 enableMVCC=false
 enableMavlPrune=false
 pruneHeight=10000
+enableMemTree=true
+enableMemVal=true
+
+[store.sub.kvmvccmavl]
+enableMVCCIter=true
+enableMavlPrefix=false
+enableMVCC=false
+enableMavlPrune=false
+pruneHeight=10000
+enableMemTree=true
+enableMemVal=true
 
 [wallet]
 minFee=100000
@@ -134,31 +150,135 @@ minerdisable=true
 isFree=true
 minExecFee=100000
 enableStat=false
+enableMVCC=false
 
 [exec.sub.relay]
-genesis="12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv"
+genesis="1JmFaA6unrCFYEWPGRi7uuXY1KthTJxJEP"
 
 [exec.sub.manage]
-superManager=[
-    "1Bsg9j6gW83sShoee1fZAt9TkUjcrCgA9S",
-    "12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv",
-    "1Q8hGLfoGe63efeWa8fJ4Pnukhkngt6poK"
-]
+superManager=["1JmFaA6unrCFYEWPGRi7uuXY1KthTJxJEP"]
 
 [exec.sub.token]
 saveTokenTxList=true
-tokenApprs = [
-	"1Bsg9j6gW83sShoee1fZAt9TkUjcrCgA9S",
-	"1Q8hGLfoGe63efeWa8fJ4Pnukhkngt6poK",
-	"1LY8GFia5EiyoTodMLfkB5PHNNpXRqxhyB",
-	"1GCzJDS6HbgTQ2emade7mEJGGWFfA15pS9",
-	"1JYB8sxi4He5pZWHCd3Zi2nypQ4JMB6AxN",
-	"12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv",
-]
+tokenApprs=[]
 
 [exec.sub.paracross]
-#平行链自共识停止n个空块的对应主链高度后，超级账户可以直接参与投票
-paraConsensusStopBlocks=100
+#平行链自共识停止n个空块的对应主链高度后，超级账户可以直接参与投票,这个高度只在主链有效
+paraConsensusStopBlocks=30000
+
+
+#系统中所有的fork,默认用chain33的测试网络的
+#但是我们可以替换
+[fork.system]
+ForkChainParamV1= 0
+ForkCheckTxDup=0
+ForkBlockHash= 1
+ForkMinerTime= 0
+ForkTransferExec=0
+ForkExecKey=0
+ForkTxGroup=0
+ForkResetTx0=0
+ForkWithdraw=0
+ForkExecRollback=0
+ForkCheckBlockTime=0
+ForkTxHeight=0
+ForkTxGroupPara=0
+ForkChainParamV2=0
+ForkMultiSignAddress=0
+ForkStateDBSet=0
+ForkLocalDBAccess=0
+ForkBlockCheck=0
+ForkBase58AddressCheck=0
+#平行链上使能平行链执行器如user.p.x.coins执行器的注册，缺省为0，对已有的平行链需要设置一个fork高度
+ForkEnableParaRegExec=0
+
+[fork.sub.coins]
+Enable=0
+
+[fork.sub.ticket]
+Enable=0
+ForkTicketId =0
+ForkTicketVrf =0
+
+[fork.sub.retrieve]
+Enable=0
+ForkRetrive=0
+
+[fork.sub.hashlock]
+Enable=0
+
+[fork.sub.manage]
+Enable=0
+ForkManageExec=0
+
+[fork.sub.token]
+Enable=0
+ForkTokenBlackList= 0
+ForkBadTokenSymbol= 0
+ForkTokenPrice=0
+ForkTokenSymbolWithNumber=0
+ForkTokenCheck= 0
+
+[fork.sub.trade]
+Enable=0
+ForkTradeBuyLimit= 0
+ForkTradeAsset= 0
+ForkTradeID = 0
+
+[fork.sub.paracross]
+Enable=0
+ForkParacrossWithdrawFromParachain=0
+ForkParacrossCommitTx=0
+
+[fork.sub.evm]
+Enable=0
+ForkEVMState=0
+ForkEVMABI=0
+ForkEVMFrozen=0
+ForkEVMKVHash=0
+
+[fork.sub.blackwhite]
+Enable=0
+ForkBlackWhiteV2=0
+
+[fork.sub.cert]
+Enable=0
+
+[fork.sub.guess]
+Enable=0
+
+[fork.sub.lottery]
+Enable=0
+
+[fork.sub.oracle]
+Enable=0
+
+[fork.sub.relay]
+Enable=0
+
+[fork.sub.norm]
+Enable=0
+
+[fork.sub.pokerbull]
+Enable=0
+
+[fork.sub.privacy]
+Enable=0
+
+[fork.sub.game]
+Enable=0
+
+[fork.sub.multisig]
+Enable=0
+
+[fork.sub.unfreeze]
+Enable=0
+ForkTerminatePart=0
+ForkUnfreezeIDX= 0
+
+#对已有的平行链如果不是从0开始同步数据，需要设置这个kvmvccmavl的fork，如果从0开始同步，statedb会跟以前mavl的不同
+[fork.sub.store-kvmvccmavl]
+ForkKvmvccmavl=0
 
 [pprof]
 listenAddr = "localhost:6061"

--- a/plugin/dapp/paracross/cmd/build/testcase.sh
+++ b/plugin/dapp/paracross/cmd/build/testcase.sh
@@ -42,10 +42,22 @@ function para_set_toml() {
     sed -i $xsedfix 's/^MainForkParacrossCommitTx=.*/MainForkParacrossCommitTx=1/g' "${1}"
 
     # rpc
-    sed -i $xsedfix 's/^jrpcBindAddr=.*/jrpcBindAddr="0.0.0.0:8901"/g' "${1}"
-    sed -i $xsedfix 's/^grpcBindAddr=.*/grpcBindAddr="0.0.0.0:8902"/g' "${1}"
     sed -i $xsedfix 's/^whitelist=.*/whitelist=["localhost","127.0.0.1","0.0.0.0"]/g' "${1}"
     sed -i $xsedfix 's/^ParaRemoteGrpcClient=.*/ParaRemoteGrpcClient="nginx:8803"/g' "${1}"
+
+    sed -i $xsedfix 's/^genesis="1JmFaA6unrCFYEWP.*/genesis="12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv"/g' "${1}"
+    # shellcheck disable=SC1004
+    sed -i $xsedfix 's/^superManager=.*/superManager=["1Bsg9j6gW83sShoee1fZAt9TkUjcrCgA9S",\
+                                                        "12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv",\
+                                                        "1Q8hGLfoGe63efeWa8fJ4Pnukhkngt6poK"]/g' "${1}"
+    # shellcheck disable=SC1004
+    sed -i $xsedfix 's/^tokenApprs=.*/tokenApprs=[	"1Bsg9j6gW83sShoee1fZAt9TkUjcrCgA9S",\
+	                                                "1Q8hGLfoGe63efeWa8fJ4Pnukhkngt6poK",\
+                                                    "1LY8GFia5EiyoTodMLfkB5PHNNpXRqxhyB",\
+                                                    "1GCzJDS6HbgTQ2emade7mEJGGWFfA15pS9",\
+                                                    "1JYB8sxi4He5pZWHCd3Zi2nypQ4JMB6AxN",\
+	                                                "12qyocayNF7Lv6C9qW4avxs2E7U41fKSfv",]/g' "${1}"
+
 }
 
 function para_set_wallet() {

--- a/plugin/dapp/paracross/executor/query.go
+++ b/plugin/dapp/paracross/executor/query.go
@@ -63,10 +63,11 @@ func (p *Paracross) Query_GetTitleByHash(in *pt.ReqParacrossTitleHash) (types.Me
 
 //Query_GetNodeGroupAddrs get node group addrs
 func (p *Paracross) Query_GetNodeGroupAddrs(in *pt.ReqParacrossNodeInfo) (types.Message, error) {
-	if in == nil {
+	if in == nil || in.GetTitle() == "" {
 		return nil, types.ErrInvalidParam
 	}
-	ret, _, err := getParacrossNodes(p.GetStateDB(), in.GetTitle())
+
+	ret, key, err := getConfigNodes(p.GetStateDB(), in.GetTitle())
 	if err != nil {
 		return nil, errors.Cause(err)
 	}
@@ -75,7 +76,7 @@ func (p *Paracross) Query_GetNodeGroupAddrs(in *pt.ReqParacrossNodeInfo) (types.
 		nodes = append(nodes, k)
 	}
 	var reply types.ReplyConfig
-	reply.Key = string(calcParaNodeGroupAddrsKey(in.GetTitle()))
+	reply.Key = string(key)
 	reply.Value = fmt.Sprint(nodes)
 	return &reply, nil
 }


### PR DESCRIPTION
fixes #513 
1，平行链共识交易共识停止一定次数后重发
2，授权节点检查是否在超级账户组里面来决定发送
3，配置缺省平行链toml文件