### PR TITLE
Fix trade order before forkasset

### DIFF
--- a/chain33.para.toml
+++ b/chain33.para.toml
@@ -234,7 +234,7 @@ Enable=0
 ForkTradeBuyLimit= 0
 ForkTradeAsset= 0
 ForkTradeID = 0
-ForkTradeFixAssetDBX = 0
+ForkTradeFixAssetDB = 0
 
 [fork.sub.paracross]
 Enable=0

--- a/chain33.para.toml
+++ b/chain33.para.toml
@@ -234,6 +234,7 @@ Enable=0
 ForkTradeBuyLimit= 0
 ForkTradeAsset= 0
 ForkTradeID = 0
+ForkTradeFixAssetDBX = 0
 
 [fork.sub.paracross]
 Enable=0

--- a/plugin/dapp/trade/executor/util.go
+++ b/plugin/dapp/trade/executor/util.go
@@ -48,7 +48,12 @@ func checkAsset(height int64, exec, symbol string) bool {
 }
 
 func createAccountDB(height int64, db db.KV, exec, symbol string) (*account.DB, error) {
-	if types.IsDappFork(height, pt.TradeX, pt.ForkTradeAssetX) {
+	if types.IsDappFork(height, pt.TradeX, pt.ForkTradeFixAssetDBX) {
+		if exec == "" {
+			exec = defaultAssetExec
+		}
+		return account.NewAccountDB(exec, symbol, db)
+	} else if types.IsDappFork(height, pt.TradeX, pt.ForkTradeAssetX) {
 		return account.NewAccountDB(exec, symbol, db)
 	}
 

--- a/plugin/dapp/trade/types/const.go
+++ b/plugin/dapp/trade/types/const.go
@@ -90,6 +90,6 @@ const (
 	ForkTradeBuyLimitX = "ForkTradeBuyLimit"
 	// ForkTradeIDX id without prefix
 	ForkTradeIDX = "ForkTradeID"
-	// ForkTradeFixCreateAssetDBX fix bug: order create before ForkTradeAssetX, cannot trade after ForkTradeAssetX
+	// ForkTradeFixAssetDBX fix bug: order create before ForkTradeAssetX, cannot trade after ForkTradeAssetX
 	ForkTradeFixAssetDBX = "ForkTradeFixAssetDB"
 )

--- a/plugin/dapp/trade/types/const.go
+++ b/plugin/dapp/trade/types/const.go
@@ -90,4 +90,6 @@ const (
 	ForkTradeBuyLimitX = "ForkTradeBuyLimit"
 	// ForkTradeIDX id without prefix
 	ForkTradeIDX = "ForkTradeID"
+	// ForkTradeFixCreateAssetDBX fix bug: order create before ForkTradeAssetX, cannot trade after ForkTradeAssetX
+	ForkTradeFixAssetDBX = "ForkTradeFixAssetDB"
 )

--- a/plugin/dapp/trade/types/trade.go
+++ b/plugin/dapp/trade/types/trade.go
@@ -55,6 +55,7 @@ func init() {
 	types.RegisterDappFork(TradeX, ForkTradeBuyLimitX, 301000)
 	types.RegisterDappFork(TradeX, ForkTradeAssetX, 1010000)
 	types.RegisterDappFork(TradeX, ForkTradeIDX, 1450000)
+	types.RegisterDappFork(TradeX, ForkTradeFixAssetDBX, 2500000)
 }
 
 type tradeType struct {


### PR DESCRIPTION
和支持多种资产有关， 在fork之前都是 token 资产， 之后需要指定资产合约名。 订单在fork之前发， 买单在fork之后
这种情况下， 代码在读取资产所在合约为空
close #555 