### PR TITLE
add build/find-fork.bash

### DIFF
--- a/build/find-fork.bash
+++ b/build/find-fork.bash
@@ -26,9 +26,7 @@ function subdir_forks() {
 	for fork in "${forks}"
 	do
 		echo "${fork}" | awk -F ',' '{ \
-					if(match($1,"\"")) gsub("\"","",$1); else $1=$plugin_name; \
 					if(match($2,"\"")) gsub("\"","",$2); else gsub("X$","",$2); \
-					pirnt $1; \
 				    	print $2 "=" $3}'
 					#/*print "debug" $1 $2 $3;*/ \
 

--- a/build/find-fork.bash
+++ b/build/find-fork.bash
@@ -38,7 +38,7 @@ function subdir_forks() {
 
 
 dir=$(go list -f '{{.Dir}}' github.com/33cn/plugin)/plugin/
-plugins=$(find $dir -maxdepth 2 -mindepth 2 -type d)
+plugins=$(find $dir -maxdepth 2 -mindepth 2 -type d | sort)
 for plugin in ${plugins}
 do 
 	name=$(echo $plugin | sed 's/.*\///g')

--- a/build/find-fork.bash
+++ b/build/find-fork.bash
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+
+
+# 在 plugin/plugin_type/plugin_name 找出fork
+function subdir_forks() {
+	plugin_dir=$1
+	plugin_name=$2
+
+	full_dir=$1
+
+	forks=$(grep types.RegisterDappFork "${full_dir}" -R | cut -d '(' -f 2 | cut -d ')' -f 1 | sed 's/ //g')
+
+        if [ -z "${forks}" ]; then
+		return
+	fi
+	
+	cnt=$(echo "${forks}" | grep "^\"" | wc -l)
+	if [ $cnt -gt 0 ]; then
+		name=$(echo $forks | head -n1 | cut -d ',' -f 1 | sed 's/"//g')
+		echo "[fork.sub.${name}]"
+	else
+		echo "[fork.sub.${plugin_name}]";
+	fi
+
+	for fork in "${forks}"
+	do
+		echo "${fork}" | awk -F ',' '{ \
+					if(match($1,"\"")) gsub("\"","",$1); else $1=$plugin_name; \
+					if(match($2,"\"")) gsub("\"","",$2); else gsub("X$","",$2); \
+					pirnt $1; \
+				    	print $2 "=" $3}'
+					#/*print "debug" $1 $2 $3;*/ \
+
+	done
+	echo 
+}
+
+
+dir=$(go list -f '{{.Dir}}' github.com/33cn/plugin)/plugin/
+plugins=$(find $dir -maxdepth 2 -mindepth 2 -type d)
+for plugin in ${plugins}
+do 
+	name=$(echo $plugin | sed 's/.*\///g')
+	subdir_forks $plugin $name
+done


### PR DESCRIPTION
调用 ../build/find-fork.bash , 按插件字母序列出fork

可以在使用方更新 plugin 的时候，快速找出 fork， 方便配置

只包含 fork.sub 部分

```
$ ./build/find-fork.bash  
[fork.sub.autonomy]
Enable=0

[fork.sub.blackwhite]
ForkBlackWhiteV2=900000
Enable=850000

[fork.sub.cert]
Enable=0

[fork.sub.dposvote]
Enable=0

[fork.sub.evm]
EVMEnable=500000
ForkEVMState=650000

```
close #659 