### PR TITLE
fix evm rpc test

### DIFF
--- a/build/docker-compose.yml
+++ b/build/docker-compose.yml
@@ -2,25 +2,31 @@ version: '3'
 
 services:
   chain33:
+    container_name: build_chain33_1
     build:
       context: .
 
   chain32:
+    container_name: build_chain32_1
     build:
       context: .
 
   chain31:
+    container_name: build_chain31_1
     build:
       context: .
 
   chain30:
+    container_name: build_chain30_1
     build:
       context: .
 
   chain29:
+    container_name: build_chain29_1
     build:
       context: .
 
   chain28:
+    container_name: build_chain28_1
     build:
       context: .

--- a/plugin/dapp/evm/cmd/test/test-rpc.sh
+++ b/plugin/dapp/evm/cmd/test/test-rpc.sh
@@ -124,19 +124,11 @@ function queryTransaction() {
     else
         res=$(curl -s --data-binary '{"jsonrpc":"2.0","id":2,"method":"Chain33.QueryTransaction","params":[{"hash":"'"${txHash}"'"}]}' -H 'content-type:text/plain;' ${MAIN_HTTP})
         if [ "${evm_addr}" == "" ]; then
-            if [ "$ispara" == "true" ]; then
-                evm_addr=$(echo "${res}" | jq -r ".result.receipt.logs[0].log.contractName")
-            else
-                evm_addr=$(echo "${res}" | jq -r ".result.receipt.logs[1].log.contractName")
-            fi
+            evm_addr="user.evm.${txHash}"
         fi
 
         if [ "${evm_contractAddr}" == "" ]; then
-            if [ "$ispara" == "true" ]; then
-                evm_contractAddr=$(echo "${res}" | jq -r ".result.receipt.logs[0].log.contractAddr")
-            else
-                evm_contractAddr=$(echo "${res}" | jq -r ".result.receipt.logs[1].log.contractAddr")
-            fi
+            evm_contractAddr=$(curl -ksd '{"method":"Chain33.ConvertExectoAddr","params":[{"execname":"'"${evm_addr}"'"}]}' ${MAIN_HTTP} | jq -r ".result")
 
         fi
         return 0


### PR DESCRIPTION
1、测试脚本中用到了容器名，docker-compose.yml中显式指定每个容器的容器名，防止默认容器名发生变化导致测试不通过
2、解决evm对精简localdb前的receipt的依赖问题