### PR TITLE
add by hyb for Consensus policy Conflict

### DIFF
--- a/plugin/dapp/ticket/wallet/ticket.go
+++ b/plugin/dapp/ticket/wallet/ticket.go
@@ -97,6 +97,11 @@ func (policy *ticketPolicy) IsTicketLocked() bool {
 	return atomic.LoadInt32(&policy.isTicketLocked) != 0
 }
 
+// PolicyName Policy Name
+func (policy *ticketPolicy) PolicyName() string {
+	return ty.TicketX
+}
+
 // Init initial
 func (policy *ticketPolicy) Init(walletBiz wcom.WalletOperate, sub []byte) {
 	policy.setWalletOperate(walletBiz)

--- a/plugin/dapp/ticket/wallet/ticket.go
+++ b/plugin/dapp/ticket/wallet/ticket.go
@@ -99,6 +99,7 @@ func (policy *ticketPolicy) IsTicketLocked() bool {
 
 // PolicyName Policy Name
 func (policy *ticketPolicy) PolicyName() string {
+
 	return ty.TicketX
 }
 

--- a/plugin/p2p/gossip/p2p_test.go
+++ b/plugin/p2p/gossip/p2p_test.go
@@ -44,6 +44,9 @@ func processMsg(q queue.Queue) {
 		wcli := wallet.New(cfg)
 		client := q.Client()
 		wcli.SetQueueClient(client)
+		defer func(path string) {
+			_ = os.RemoveAll(path)
+		}(cfg.GetModuleConfig().Wallet.DbPath)
 		//导入种子，解锁钱包
 		password := "a12345678"
 		seed := "cushion canal bitter result harvest sentence ability time steel basket useful ask depth sorry area course purpose search exile chapter mountain project ranch buffalo"

--- a/plugin/p2p/gossip/process.go
+++ b/plugin/p2p/gossip/process.go
@@ -127,7 +127,7 @@ func (n *Node) sendBlock(block *types.P2PBlock, p2pData *types.BroadCastData, pe
 
 		// cache block
 		if !totalBlockCache.Contains(blockHash) {
-			totalBlockCache.Add(blockHash, block.Block, ltBlock.Size)
+			totalBlockCache.Add(blockHash, block.Block, int(ltBlock.Size))
 		}
 
 		p2pData.Value = &types.BroadCastData_LtBlock{LtBlock: ltBlock}
@@ -355,7 +355,7 @@ func (n *Node) recvLtBlock(ltBlock *types.LightBlock, pid, peerAddr string, pubP
 	//pub to specified peer
 	pubPeerFunc(query, pid)
 	//需要将不完整的block预存
-	ltBlockCache.Add(blockHash, block, int64(block.Size()))
+	ltBlockCache.Add(blockHash, block, block.Size())
 }
 
 func (n *Node) recvQueryData(query *types.P2PQueryData, pid, peerAddr string, pubPeerFunc pubFuncType) {
@@ -443,7 +443,7 @@ func (n *Node) recvQueryReply(rep *types.P2PBlockTxReply, pid, peerAddr string, 
 		//pub to specified peer
 		pubPeerFunc(query, pid)
 		block.Txs = nil
-		ltBlockCache.Add(rep.BlockHash, block, int64(block.Size()))
+		ltBlockCache.Add(rep.BlockHash, block, block.Size())
 	}
 }
 


### PR DESCRIPTION
RegisterMineStatusReporter 函数处理时需要检测当前的共识和wallet插件是否有冲突，不允许注册有冲突的钱包插件 。
相应的plugin工程的ticket和pos33 wallet 插件需要实现PolicyName() 方法，返回各自的wallet插件名字