### PR TITLE
增加grpc tls通信

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaW
 github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
 github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf h1:gFVkHXmVAhEbxZVDln5V9GKrLaluNoFHDbrZwAWZgws=
 github.com/golang/snappy v0.0.2-0.20190904063534-ff6b7dc882cf/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -238,6 +239,7 @@ github.com/ipfs/go-ds-badger v0.2.3/go.mod h1:pEYw0rgg3FIrywKKnL+Snr+w/LjJZVMTBR
 github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIykR4L04tMOYc=
 github.com/ipfs/go-ds-leveldb v0.1.0/go.mod h1:hqAW8y4bwX5LWcCtku2rFNX3vjDZCy5LZCg+cSZvYb8=
 github.com/ipfs/go-ds-leveldb v0.4.2/go.mod h1:jpbku/YqBSsBc1qgME8BkWS4AxzF2cEu1Ii2r79Hh9s=
+github.com/ipfs/go-ipfs-addr v0.0.1/go.mod h1:uKTDljHT3Q3SUWzDLp3aYUi8MrY32fgNgogsIa0npjg=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
 github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
 github.com/ipfs/go-ipfs-util v0.0.2 h1:59Sswnk1MFaiq+VcaknX7aYEyGyGDAA73ilhEK2POp8=
@@ -343,6 +345,7 @@ github.com/libp2p/go-libp2p-core v0.5.7/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX
 github.com/libp2p/go-libp2p-core v0.6.0/go.mod h1:txwbVEhHEXikXn9gfC7/UDDw7rkxuX0bJvM49Ykaswo=
 github.com/libp2p/go-libp2p-core v0.6.1 h1:XS+Goh+QegCDojUZp00CaPMfiEADCrLjNZskWE7pvqs=
 github.com/libp2p/go-libp2p-core v0.6.1/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
+github.com/libp2p/go-libp2p-crypto v0.0.1/go.mod h1:yJkNyDmO341d5wwXxDUGO0LykUVT72ImHNUqh5D/dBE=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfxg97AEdo4GYBt6BadWg=
 github.com/libp2p/go-libp2p-discovery v0.5.0 h1:Qfl+e5+lfDgwdrXdu4YNCWyEo3fWuP+WgN9mN0iWviQ=
@@ -362,6 +365,7 @@ github.com/libp2p/go-libp2p-nat v0.0.5/go.mod h1:1qubaE5bTZMJE+E/uu2URroMbzdubFz
 github.com/libp2p/go-libp2p-nat v0.0.6 h1:wMWis3kYynCbHoyKLPBEMu4YRLltbm8Mk08HGSfvTkU=
 github.com/libp2p/go-libp2p-nat v0.0.6/go.mod h1:iV59LVhB3IkFvS6S6sauVTSOrNEANnINbI/fkaLimiw=
 github.com/libp2p/go-libp2p-netutil v0.1.0/go.mod h1:3Qv/aDqtMLTUyQeundkKsA+YCThNdbQD54k3TqjpbFU=
+github.com/libp2p/go-libp2p-peer v0.0.1/go.mod h1:nXQvOBbwVqoP+T5Y5nCjeH4sP9IX/J0AMzcDUVruVoo=
 github.com/libp2p/go-libp2p-peer v0.2.0/go.mod h1:RCffaCvUyW2CJmG2gAWVqwePwW7JMgxjsHm7+J5kjWY=
 github.com/libp2p/go-libp2p-peerstore v0.1.0/go.mod h1:2CeHkQsr8svp4fZ+Oi9ykN1HBb6u0MOvdJ7YIsmcwtY=
 github.com/libp2p/go-libp2p-peerstore v0.1.3/go.mod h1:BJ9sHlm59/80oSkpWgr1MyY1ciXAXV397W6h1GH/uKI=
@@ -734,6 +738,7 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7 h1:AeiKBIuRw3UomYXSbLy0Mc2dDLfdtbT/IVn4keq83P0=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -811,6 +816,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1 h1:EC2SB8S04d2r73uptxphDSUG+kTKVgjRPF+N3xpxRB4=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=

--- a/plugin/p2p/gossip/common.go
+++ b/plugin/p2p/gossip/common.go
@@ -8,14 +8,14 @@ import (
 	"bytes"
 	"encoding/binary"
 	"encoding/hex"
+	"github.com/33cn/chain33/common/crypto"
+	"github.com/33cn/chain33/types"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"math/rand"
 	"net"
 	"strings"
 	"time"
-
-	"github.com/33cn/chain33/common/crypto"
-	"github.com/33cn/chain33/types"
-	"google.golang.org/grpc"
 )
 
 // P2pComm p2p communication
@@ -25,7 +25,7 @@ var P2pComm Comm
 type Comm struct{}
 
 // AddrRouteble address router ,return enbale address
-func (Comm) AddrRouteble(addrs []string, version int32) []string {
+func (Comm) AddrRouteble(addrs []string, version int32,creds credentials.TransportCredentials) []string {
 	var enableAddrs []string
 
 	for _, addr := range addrs {
@@ -34,7 +34,7 @@ func (Comm) AddrRouteble(addrs []string, version int32) []string {
 			log.Error("AddrRouteble", "NewNetAddressString", err.Error())
 			continue
 		}
-		conn, err := netaddr.DialTimeout(version)
+		conn, err := netaddr.DialTimeout(version,creds)
 		if err != nil {
 			//log.Error("AddrRouteble", "DialTimeout", err.Error())
 			continue
@@ -77,7 +77,7 @@ func (c Comm) GetLocalAddr() string {
 
 func (c Comm) dialPeerWithAddress(addr *NetAddress, persistent bool, node *Node) (*Peer, error) {
 	log.Debug("dialPeerWithAddress")
-	conn, err := addr.DialTimeout(node.nodeInfo.channelVersion)
+	conn, err := addr.DialTimeout(node.nodeInfo.channelVersion,node.cliCreds)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/p2p/gossip/common.go
+++ b/plugin/p2p/gossip/common.go
@@ -25,7 +25,7 @@ var P2pComm Comm
 type Comm struct{}
 
 // AddrRouteble address router ,return enbale address
-func (Comm) AddrRouteble(addrs []string, version int32,creds credentials.TransportCredentials) []string {
+func (Comm) AddrRouteble(addrs []string, version int32, creds credentials.TransportCredentials) []string {
 	var enableAddrs []string
 
 	for _, addr := range addrs {
@@ -34,7 +34,7 @@ func (Comm) AddrRouteble(addrs []string, version int32,creds credentials.Transpo
 			log.Error("AddrRouteble", "NewNetAddressString", err.Error())
 			continue
 		}
-		conn, err := netaddr.DialTimeout(version,creds)
+		conn, err := netaddr.DialTimeout(version, creds)
 		if err != nil {
 			//log.Error("AddrRouteble", "DialTimeout", err.Error())
 			continue
@@ -77,7 +77,7 @@ func (c Comm) GetLocalAddr() string {
 
 func (c Comm) dialPeerWithAddress(addr *NetAddress, persistent bool, node *Node) (*Peer, error) {
 	log.Debug("dialPeerWithAddress")
-	conn, err := addr.DialTimeout(node.nodeInfo.channelVersion,node.cliCreds)
+	conn, err := addr.DialTimeout(node.nodeInfo.channelVersion, node.nodeInfo.cliCreds)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/p2p/gossip/listener.go
+++ b/plugin/p2p/gossip/listener.go
@@ -144,6 +144,9 @@ Retry:
 	keepOp := grpc.KeepaliveParams(keepparm)
 	StatsOp := grpc.StatsHandler(&statshandler{})
 	opts = append(opts, msgRecvOp, msgSendOp, grpc.KeepaliveEnforcementPolicy(kaep), keepOp, maxStreams, StatsOp)
+	if node.servCreds!=nil{
+		opts=append(opts,grpc.Creds(node.servCreds))
+	}
 	dl.server = grpc.NewServer(opts...)
 	dl.p2pserver = pServer
 	pb.RegisterP2PgserviceServer(dl.server, pServer)

--- a/plugin/p2p/gossip/listener.go
+++ b/plugin/p2p/gossip/listener.go
@@ -144,8 +144,8 @@ Retry:
 	keepOp := grpc.KeepaliveParams(keepparm)
 	StatsOp := grpc.StatsHandler(&statshandler{})
 	opts = append(opts, msgRecvOp, msgSendOp, grpc.KeepaliveEnforcementPolicy(kaep), keepOp, maxStreams, StatsOp)
-	if node.servCreds!=nil{
-		opts=append(opts,grpc.Creds(node.servCreds))
+	if node.nodeInfo.servCreds != nil {
+		opts = append(opts, grpc.Creds(node.nodeInfo.servCreds))
 	}
 	dl.server = grpc.NewServer(opts...)
 	dl.p2pserver = pServer

--- a/plugin/p2p/gossip/net_test.go
+++ b/plugin/p2p/gossip/net_test.go
@@ -28,7 +28,7 @@ func TestNetAddress(t *testing.T) {
 }
 
 func TestAddrRouteble(t *testing.T) {
-	resp := P2pComm.AddrRouteble([]string{"114.55.101.159:13802"}, utils.CalcChannelVersion(119, VERSION))
+	resp := P2pComm.AddrRouteble([]string{"114.55.101.159:13802"}, utils.CalcChannelVersion(119, VERSION),nil)
 	t.Log(resp)
 }
 
@@ -43,7 +43,7 @@ func TestP2pListen(t *testing.T) {
 	assert.Equal(t, true, listen1 != nil)
 	listen2 := newListener("tcp", &node)
 	assert.Equal(t, true, listen2 != nil)
-
-	listen1.Close()
 	listen2.Close()
+	listen1.Close()
+
 }

--- a/plugin/p2p/gossip/net_test.go
+++ b/plugin/p2p/gossip/net_test.go
@@ -39,7 +39,7 @@ func TestGetLocalAddr(t *testing.T) {
 func TestP2pListen(t *testing.T) {
 	var node Node
 	node.listenPort = 3333
-	node.nodeInfo=&NodeInfo{}
+	node.nodeInfo = &NodeInfo{}
 	listen1 := newListener("tcp", &node)
 	assert.Equal(t, true, listen1 != nil)
 	listen2 := newListener("tcp", &node)

--- a/plugin/p2p/gossip/net_test.go
+++ b/plugin/p2p/gossip/net_test.go
@@ -39,6 +39,7 @@ func TestGetLocalAddr(t *testing.T) {
 func TestP2pListen(t *testing.T) {
 	var node Node
 	node.listenPort = 3333
+	node.nodeInfo=&NodeInfo{}
 	listen1 := newListener("tcp", &node)
 	assert.Equal(t, true, listen1 != nil)
 	listen2 := newListener("tcp", &node)

--- a/plugin/p2p/gossip/node.go
+++ b/plugin/p2p/gossip/node.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"math/rand"
 
+	"google.golang.org/grpc/credentials"
+
 	"github.com/33cn/chain33/p2p"
 
 	//"strings"
@@ -82,6 +84,8 @@ type Node struct {
 	pubsub     *pubsub.PubSub
 	chainCfg   *types.Chain33Config
 	p2pMgr     *p2p.Manager
+	cliCreds   credentials.TransportCredentials
+	servCreds  credentials.TransportCredentials
 }
 
 // SetQueueClient return client for nodeinfo
@@ -124,6 +128,19 @@ func NewNode(mgr *p2p.Manager, mcfg *subConfig) (*Node, error) {
 		node.server = newListener(protocol, node)
 	}
 	node.chainCfg = cfg
+	if mcfg.enableTls { //读取证书，初始化tls客户端
+		var err error
+		node.cliCreds, err = credentials.NewClientTLSFromFile(cfg.GetModuleConfig().RPC.CertFile, "")
+		if err != nil {
+			panic(err)
+		}
+		node.servCreds, err = credentials.NewServerTLSFromFile(cfg.GetModuleConfig().RPC.CertFile, cfg.GetModuleConfig().RPC.KeyFile)
+		if err != nil {
+			panic(err)
+		}
+
+	}
+
 	return node, nil
 }
 
@@ -157,7 +174,7 @@ func (n *Node) doNat() {
 	}
 	testExaddr := fmt.Sprintf("%v:%v", n.nodeInfo.GetExternalAddr().IP.String(), n.listenPort)
 	log.Info("TestNetAddr", "testExaddr", testExaddr)
-	if len(P2pComm.AddrRouteble([]string{testExaddr}, n.nodeInfo.channelVersion)) != 0 {
+	if len(P2pComm.AddrRouteble([]string{testExaddr}, n.nodeInfo.channelVersion, n.cliCreds)) != 0 {
 		log.Info("node outside")
 		n.nodeInfo.SetNetSide(true)
 		if netexaddr, err := NewNetAddressString(testExaddr); err == nil {
@@ -433,7 +450,7 @@ func (n *Node) natMapPort() {
 		time.Sleep(time.Second)
 	}
 	var err error
-	if len(P2pComm.AddrRouteble([]string{n.nodeInfo.GetExternalAddr().String()}, n.nodeInfo.channelVersion)) != 0 { //判断能否连通要映射的端口
+	if len(P2pComm.AddrRouteble([]string{n.nodeInfo.GetExternalAddr().String()}, n.nodeInfo.channelVersion, n.cliCreds)) != 0 { //判断能否连通要映射的端口
 		log.Info("natMapPort", "addr", "routeble")
 		p2pcli := NewNormalP2PCli() //检查要映射的IP地址是否已经被映射成功
 		ok := p2pcli.CheckSelf(n.nodeInfo.GetExternalAddr().String(), n.nodeInfo)

--- a/plugin/p2p/gossip/node.go
+++ b/plugin/p2p/gossip/node.go
@@ -122,9 +122,6 @@ func NewNode(mgr *p2p.Manager, mcfg *subConfig) (*Node, error) {
 		node.cfgSeeds.Store(seed, "cfg")
 	}
 	node.nodeInfo = NewNodeInfo(cfg.GetModuleConfig().P2P, mcfg)
-	if mcfg.ServerStart {
-		node.server = newListener(protocol, node)
-	}
 	node.chainCfg = cfg
 	if mcfg.EnableTls { //读取证书，初始化tls客户端
 		var err error
@@ -136,6 +133,9 @@ func NewNode(mgr *p2p.Manager, mcfg *subConfig) (*Node, error) {
 		if err != nil {
 			panic(err)
 		}
+	}
+	if mcfg.ServerStart {
+		node.server = newListener(protocol, node)
 	}
 	return node, nil
 }

--- a/plugin/p2p/gossip/nodeinfo.go
+++ b/plugin/p2p/gossip/nodeinfo.go
@@ -5,9 +5,10 @@
 package gossip
 
 import (
-	"google.golang.org/grpc/credentials"
 	"sync"
 	"sync/atomic"
+
+	"google.golang.org/grpc/credentials"
 
 	"github.com/33cn/chain33/p2p/utils"
 

--- a/plugin/p2p/gossip/nodeinfo.go
+++ b/plugin/p2p/gossip/nodeinfo.go
@@ -5,6 +5,7 @@
 package gossip
 
 import (
+	"google.golang.org/grpc/credentials"
 	"sync"
 	"sync/atomic"
 
@@ -32,6 +33,8 @@ type NodeInfo struct {
 	outSide        int32
 	ServiceType    int32
 	channelVersion int32
+	cliCreds       credentials.TransportCredentials
+	servCreds      credentials.TransportCredentials
 }
 
 // NewNodeInfo new a node object
@@ -49,6 +52,7 @@ func NewNodeInfo(p2pCfg *types.P2P, subCfg *subConfig) *NodeInfo {
 	nodeInfo.listenAddr = new(NetAddress)
 	nodeInfo.addrBook = NewAddrBook(p2pCfg, subCfg)
 	nodeInfo.channelVersion = utils.CalcChannelVersion(subCfg.Channel, VERSION)
+
 	return nodeInfo
 }
 

--- a/plugin/p2p/gossip/p2p.go
+++ b/plugin/p2p/gossip/p2p.go
@@ -59,7 +59,8 @@ type subConfig struct {
 	Channel int32 `protobuf:"varint,11,opt,name=channel" json:"channel,omitempty"`
 	//触发区块轻广播最小大小, KB
 	MinLtBlockSize int32 `protobuf:"varint,12,opt,name=minLtBlockSize" json:"minLtBlockSize,omitempty"`
-	//指定p2p类型, 支持gossip, dht
+	//是否使用证书进行节点之间的通信,true 使用证书通信，读取rpc配置项下的证书文件
+	enableTls bool `protobuf:"varint,13,opt,name=enableTls" json:"enableTls,omitempty"`
 }
 
 // P2p interface

--- a/plugin/p2p/gossip/p2p.go
+++ b/plugin/p2p/gossip/p2p.go
@@ -60,7 +60,7 @@ type subConfig struct {
 	//触发区块轻广播最小大小, KB
 	MinLtBlockSize int32 `protobuf:"varint,12,opt,name=minLtBlockSize" json:"minLtBlockSize,omitempty"`
 	//是否使用证书进行节点之间的通信,true 使用证书通信，读取rpc配置项下的证书文件
-	enableTls bool `protobuf:"varint,13,opt,name=enableTls" json:"enableTls,omitempty"`
+	EnableTls bool `protobuf:"varint,13,opt,name=enableTls" json:"enableTls,omitempty"`
 }
 
 // P2p interface

--- a/plugin/p2p/gossip/p2p_test.go
+++ b/plugin/p2p/gossip/p2p_test.go
@@ -264,7 +264,7 @@ func testPeer(t *testing.T, p2p *P2p, q queue.Queue) {
 
 	_, err = p2pcli.SendVersion(peer, localP2P.node.nodeInfo)
 	assert.Nil(t, err)
-
+	t.Log("nodeinfo",localP2P.node.nodeInfo)
 	t.Log(p2pcli.CheckPeerNatOk("localhost:53802", localP2P.node.nodeInfo))
 	t.Log("checkself:", p2pcli.CheckSelf("loadhost:43803", localP2P.node.nodeInfo))
 	_, err = p2pcli.GetAddr(peer)
@@ -557,14 +557,17 @@ RObdAoGBALP9HK7KuX7xl0cKBzOiXqnAyoMUfxvO30CsMI3DS0SrPc1p95OHswdu
 		return
 	}
 	var node Node
-	node.servCreds=	credentials.NewServerTLSFromCert(&certificate)
-	node.cliCreds=credentials.NewClientTLSFromCert(cp,"")
+	node.nodeInfo=&NodeInfo{}
+
+	servCreds:=	credentials.NewServerTLSFromCert(&certificate)
+	cliCreds:=credentials.NewClientTLSFromCert(cp,"")
 	node.listenPort = 3331
+	node.nodeInfo.servCreds=servCreds
 	newListener("tcp", &node)
 	netAddr,err:=	NewNetAddressString("localhost:3331")
 	assert.Nil(t,err)
 
-	conn,err:=grpc.Dial(netAddr.String(),grpc.WithTransportCredentials(node.cliCreds))
+	conn,err:=grpc.Dial(netAddr.String(),grpc.WithTransportCredentials(cliCreds))
 	assert.Nil(t,err)
 	assert.NotNil(t,conn)
 	conn.Close()

--- a/plugin/p2p/gossip/p2p_test.go
+++ b/plugin/p2p/gossip/p2p_test.go
@@ -265,7 +265,7 @@ func testPeer(t *testing.T, p2p *P2p, q queue.Queue) {
 
 	_, err = p2pcli.SendVersion(peer, localP2P.node.nodeInfo)
 	assert.Nil(t, err)
-	t.Log("nodeinfo",localP2P.node.nodeInfo)
+	t.Log("nodeinfo", localP2P.node.nodeInfo)
 	t.Log(p2pcli.CheckPeerNatOk("localhost:53802", localP2P.node.nodeInfo))
 	t.Log("checkself:", p2pcli.CheckSelf("loadhost:43803", localP2P.node.nodeInfo))
 	_, err = p2pcli.GetAddr(peer)
@@ -557,20 +557,19 @@ RObdAoGBALP9HK7KuX7xl0cKBzOiXqnAyoMUfxvO30CsMI3DS0SrPc1p95OHswdu
 		return
 	}
 	var node Node
-	node.nodeInfo=&NodeInfo{}
-	servCreds:=	credentials.NewServerTLSFromCert(&certificate)
-	cliCreds:=credentials.NewClientTLSFromCert(cp,"")
+	node.nodeInfo = &NodeInfo{}
+	servCreds := credentials.NewServerTLSFromCert(&certificate)
+	cliCreds := credentials.NewClientTLSFromCert(cp, "")
 
 	node.listenPort = 3331
-	node.nodeInfo.servCreds=servCreds
+	node.nodeInfo.servCreds = servCreds
 	newListener("tcp", &node)
 	netAddr, err := NewNetAddressString("localhost:3331")
 	assert.Nil(t, err)
 
-
-	conn,err:=grpc.Dial(netAddr.String(),grpc.WithTransportCredentials(cliCreds))
-	assert.Nil(t,err)
-	assert.NotNil(t,conn)
+	conn, err := grpc.Dial(netAddr.String(), grpc.WithTransportCredentials(cliCreds))
+	assert.Nil(t, err)
+	assert.NotNil(t, conn)
 	conn.Close()
 
 	conn, err = grpc.Dial(netAddr.String())

--- a/plugin/p2p/gossip/p2pcli.go
+++ b/plugin/p2p/gossip/p2pcli.go
@@ -561,7 +561,7 @@ func (m *Cli) GetNetInfo(msg *queue.Message, taskindex int64) {
 // CheckPeerNatOk check peer is ok or not
 func (m *Cli) CheckPeerNatOk(addr string, info *NodeInfo) bool {
 	//连接自己的地址信息做测试
-	return !(len(P2pComm.AddrRouteble([]string{addr}, info.channelVersion,m.network.node.cliCreds)) == 0)
+	return !(len(P2pComm.AddrRouteble([]string{addr}, info.channelVersion,nil)) == 0)
 
 }
 
@@ -572,7 +572,7 @@ func (m *Cli) CheckSelf(addr string, nodeinfo *NodeInfo) bool {
 		log.Error("AddrRouteble", "NewNetAddressString", err.Error())
 		return false
 	}
-	conn, err := netaddr.DialTimeout(nodeinfo.channelVersion,m.network.node.cliCreds)
+	conn, err := netaddr.DialTimeout(nodeinfo.channelVersion,nodeinfo.cliCreds)
 	if err != nil {
 		return false
 	}

--- a/plugin/p2p/gossip/p2pcli.go
+++ b/plugin/p2p/gossip/p2pcli.go
@@ -561,7 +561,7 @@ func (m *Cli) GetNetInfo(msg *queue.Message, taskindex int64) {
 // CheckPeerNatOk check peer is ok or not
 func (m *Cli) CheckPeerNatOk(addr string, info *NodeInfo) bool {
 	//连接自己的地址信息做测试
-	return !(len(P2pComm.AddrRouteble([]string{addr}, info.channelVersion)) == 0)
+	return !(len(P2pComm.AddrRouteble([]string{addr}, info.channelVersion,m.network.node.cliCreds)) == 0)
 
 }
 
@@ -572,7 +572,7 @@ func (m *Cli) CheckSelf(addr string, nodeinfo *NodeInfo) bool {
 		log.Error("AddrRouteble", "NewNetAddressString", err.Error())
 		return false
 	}
-	conn, err := netaddr.DialTimeout(nodeinfo.channelVersion)
+	conn, err := netaddr.DialTimeout(nodeinfo.channelVersion,m.network.node.cliCreds)
 	if err != nil {
 		return false
 	}

--- a/plugin/p2p/gossip/p2pcli.go
+++ b/plugin/p2p/gossip/p2pcli.go
@@ -563,7 +563,6 @@ func (m *Cli) CheckPeerNatOk(addr string, info *NodeInfo) bool {
 	//连接自己的地址信息做测试
 	return !(len(P2pComm.AddrRouteble([]string{addr}, info.channelVersion, info.cliCreds)) == 0)
 
-
 }
 
 // CheckSelf check addrbook privPubKey
@@ -574,7 +573,7 @@ func (m *Cli) CheckSelf(addr string, nodeinfo *NodeInfo) bool {
 		return false
 	}
 
-	conn, err := netaddr.DialTimeout(nodeinfo.channelVersion,nodeinfo.cliCreds)
+	conn, err := netaddr.DialTimeout(nodeinfo.channelVersion, nodeinfo.cliCreds)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
通过配置项enbleTls，来读取rpc下的配置的证书和key文件，实现TLS通信服务