### PR TITLE
fix lottery rpc test

### DIFF
--- a/plugin/dapp/lottery/cmd/test/test-rpc.sh
+++ b/plugin/dapp/lottery/cmd/test/test-rpc.sh
@@ -17,8 +17,9 @@ gID=""
 lottExecAddr=""
 luckyNumber=""
 
-purNum=200
-drawNum=220
+#设置较小可能导致投注交易执行失败
+purNum=300
+drawNum=320
 opRatio=5
 devRatio=5
 
@@ -258,7 +259,7 @@ function main() {
     echo "main_ip=$MAIN_HTTP"
 
     init
-    #run_testcases
+    run_testcases
     chain33_RpcTestRst lottery "$CASE_ERR"
 }
 


### PR DESCRIPTION
purNum 设置较小，导致发送的投注交易执行失败