### PR TITLE
ticket close 优化

### DIFF
--- a/plugin/dapp/ticket/commands/ticket.go
+++ b/plugin/dapp/ticket/commands/ticket.go
@@ -216,7 +216,7 @@ func closeTicket(cmd *cobra.Command, args []string) {
 		return
 	}
 	if len(res.Hashes) == 0 {
-		fmt.Println("no ticket to be close")
+		fmt.Println("no ticket to be close or close fail,to check log")
 		return
 	}
 


### PR DESCRIPTION
fixes #1015

修改: 对出错的场景都返回错误，对交易发送失败的场景打印错误log

由于返回的结果是reply hash,  如果提示更友好，需要修改rpc 接口，不是很建议，目前提示+log 也基本满足要求
