### PR TITLE
Evm gas mechanism permission blockchain 0905

### DIFF
--- a/chain33.toml
+++ b/chain33.toml
@@ -278,6 +278,11 @@ paraConsensusStopBlocks=30000
 total="16htvcBNSEA7fZhAdLJphDwQRQJaHpyHTp"
 useBalance=false
 
+[exec.sub.evm]
+#免交易费模式联盟链允许的最大gas，该配置只对不收取交易费部署方式有效，其他部署方式下该配置不会产生作用
+#当前最大为200万
+evmGasLimit=2000000
+
 [metrics]
 #是否使能发送metrics数据的发送
 enableMetrics=false

--- a/plugin/dapp/evm/executor/exec.go
+++ b/plugin/dapp/evm/executor/exec.go
@@ -213,6 +213,15 @@ func (evm *EVMExecutor) GetMessage(tx *types.Transaction, index int, fromPtr *co
 	gasPrice := action.GasPrice
 	if gasLimit == 0 {
 		gasLimit = uint64(evm.GetTxFee(tx, index))
+		//如果未设置交易费，则尝试读取免交易费联盟链模式下的gas设置
+		if 0 == gasLimit {
+			cfg := evm.GetAPI().GetConfig()
+			conf := types.ConfSub(cfg, evmtypes.ExecutorName)
+			gasLimit = uint64(conf.GInt("evmGasLimit"))
+			if 0 == gasLimit {
+				panic("evmGasLimit is not configured for permission blockchain")
+			}
+		}
 	}
 	if gasPrice == 0 {
 		gasPrice = uint32(1)

--- a/plugin/dapp/evm/executor/exec.go
+++ b/plugin/dapp/evm/executor/exec.go
@@ -220,6 +220,7 @@ func (evm *EVMExecutor) GetMessage(tx *types.Transaction, index int, fromPtr *co
 		if 0 == gasLimit {
 			return nil, model.ErrNoGasConfigured
 		}
+		log.Info("GetMessage", "gasLimit is set to for permission blockchain", gasLimit)
 	}
 
 	if gasPrice == 0 {

--- a/plugin/dapp/evm/executor/vm/model/errors.go
+++ b/plugin/dapp/evm/executor/vm/model/errors.go
@@ -52,4 +52,6 @@ var (
 	ErrInvalidJump = errors.New("invalid jump destination")
 	// ErrInvalidRetsub invalid retsub
 	ErrInvalidRetsub = errors.New("invalid retsub")
+	// 没有配置gas
+	ErrNoGasConfigured = errors.New("ErrNoGasConfigured")
 )


### PR DESCRIPTION
1.在联盟链免交易费模式下，增加单笔evm交易最大允许gas设置；
2.忽略从action中读取gasLimit的操作，修改为从交易费转化而来，如果没有交易费设置，则从联盟链中读取