### PR TITLE
fix qbft unit test stuck

### DIFF
--- a/plugin/consensus/qbft/qbft_test.go
+++ b/plugin/consensus/qbft/qbft_test.go
@@ -41,7 +41,7 @@ func TestQbft(t *testing.T) {
 	mock33.Listen()
 	t.Log(mock33.GetGenesisAddress())
 	go startNode(t)
-	time.Sleep(2 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	configTx := configManagerTx()
 	_, err := mock33.GetAPI().SendTx(configTx)
@@ -79,6 +79,8 @@ func startNode(t *testing.T) {
 	assert.Nil(t, err)
 	sub.Consensus["qbft"] = qcfg
 	mock33_2 := testnode.NewWithConfig(cfg2, nil)
+	mock33_2.Listen()
+	time.Sleep(3 * time.Second)
 	defer clearQbftData("datadir2")
 	defer mock33_2.Close()
 


### PR DESCRIPTION
qbft 单元测试出现超时，是由于 ci 环境不稳定导致节点连接断开，修复方案为断开后进行快速重连

https://github.com/33cn/plugin/runs/4466866721?check_suite_focus=true