### PR TITLE
qbft add sameBlocktime configuration

### DIFF
--- a/plugin/consensus/qbft/qbft.go
+++ b/plugin/consensus/qbft/qbft.go
@@ -60,6 +60,7 @@ var (
 	multiBlocks           atomic.Value // 1
 	gossipVotes           atomic.Value
 	detachExec            atomic.Value // false
+	sameBlocktime         atomic.Value // false
 
 	zeroHash                    [32]byte
 	random                      *rand.Rand
@@ -114,6 +115,7 @@ type subConfig struct {
 	MultiBlocks           int64    `json:"multiBlocks"`
 	MessageInterval       int32    `json:"messageInterval"`
 	DetachExecution       bool     `json:"detachExecution"`
+	SameBlocktime         bool     `json:"sameBlocktime"`
 }
 
 func applyConfig(cfg *types.Consensus, sub []byte) {
@@ -169,6 +171,7 @@ func applyConfig(cfg *types.Consensus, sub []byte) {
 		peerGossipSleepDuration.Store(subcfg.MessageInterval)
 	}
 	detachExec.Store(subcfg.DetachExecution)
+	sameBlocktime.Store(subcfg.SameBlocktime)
 
 	gossipVotes.Store(true)
 }
@@ -551,7 +554,7 @@ func (client *Client) BuildBlock(height int64) *types.Block {
 	newblock.BlockTime = types.Now().Unix()
 	if lastBlock.BlockTime >= newblock.BlockTime {
 		// 1秒内产生的多个区块使用相同时间戳
-		if timeoutTxAvail.Load().(int32) >= 1000 || lastBlock.BlockTime > newblock.BlockTime {
+		if !sameBlocktime.Load().(bool) || lastBlock.BlockTime > newblock.BlockTime {
 			newblock.BlockTime = lastBlock.BlockTime + 1
 		}
 	}

--- a/plugin/consensus/tendermint/tools/nonePerf.go
+++ b/plugin/consensus/tendermint/tools/nonePerf.go
@@ -168,7 +168,7 @@ func Perf(host, txsize, num, sleepinterval, totalduration string) {
 					//构造存证交易
 					tx := txPool.Get().(*types.Transaction)
 					tx.To = execAddr
-					tx.Fee = rand.Int63()
+					tx.Fee = 1e6
 					tx.Nonce = time.Now().UnixNano()
 					tx.Expire = height + types.TxHeightFlag + types.LowAllowPackHeight
 					tx.Payload = RandStringBytes(sizeInt)


### PR DESCRIPTION
timeoutTxAvail 配置项不能精确控制出块时间，生产环境上配置1.5秒，出块时间仍是1秒左右，导致出现时间戳超前的区块
增加允许区块出现相同时间戳的配置项 sameBlocktime