### PR TITLE
make sure eth node is not syncing before use

### DIFF
--- a/plugin/dapp/cross2eth/ebcli/ethereumRelayerCmd.go
+++ b/plugin/dapp/cross2eth/ebcli/ethereumRelayerCmd.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/33cn/chain33/common"
 	chain33Common "github.com/33cn/chain33/common"
@@ -559,7 +561,21 @@ func LockEthErc20Asset(cmd *cobra.Command, args []string) {
 	}
 	var res rpctypes.Reply
 	ctx := jsonclient.NewRPCCtx(rpcLaddr, "Manager.LockEthErc20Asset", para, &res)
-	ctx.Run()
+	//ctx.Run
+	for try := 0; try < 3; try++ {
+		result, err := ctx.RunResult()
+		if err != nil {
+			time.Sleep(time.Millisecond * 500)
+			continue
+		}
+		data, err := json.MarshalIndent(result, "", "    ")
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
+			return
+		}
+		fmt.Println(string(data))
+		return
+	}
 }
 
 //LockEthErc20AssetAsync ...

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethinterface/ethinterface.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethinterface/ethinterface.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
@@ -17,6 +19,7 @@ type EthClientSpec interface {
 	NetworkID(ctx context.Context) (*big.Int, error)
 	BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (*big.Int, error)
 	HeaderByNumber(ctx context.Context, number *big.Int) (*types.Header, error)
+	SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error)
 }
 
 //SimExtend ...
@@ -34,11 +37,6 @@ func (sim *SimExtend) NetworkID(ctx context.Context) (*big.Int, error) {
 	return nil, nil
 }
 
-//func (sim *SimExtend) TransactionReceipt(ctx context.Context, txHash common.Hash) (*types.Receipt, error) {
-//	receipt, err := sim.SimulatedBackend.TransactionReceipt(ctx, txHash)
-//	if receipt == nil {
-//		err = errors.New("not found")
-//	}
-//
-//	return receipt, err
-//}
+func (sim *SimExtend) SyncProgress(ctx context.Context) (*ethereum.SyncProgress, error) {
+	return nil, nil
+}

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/ethtxs_test.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/ethtxs_test.go
@@ -367,3 +367,13 @@ func DeployAndInit(client ethinterface.EthClientSpec, para *DeployPara) (*X2EthC
 
 	return x2EthContracts, deployInfo, nil
 }
+
+func Test_SelectAndRoundEthURL(t *testing.T) {
+	urls := []string{"url1", "url2"}
+	decision, err := SelectAndRoundEthURL(&urls)
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "url1", decision)
+	assert.Equal(t, "url2", urls[0])
+	assert.Equal(t, "url1", urls[1])
+
+}

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/network.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/network.go
@@ -13,21 +13,21 @@ import (
 )
 
 // SelectAndRoundEthURL: 获取配置列表中的第一个配置项，同时将其调整配置配置项
-func SelectAndRoundEthURL(ethURL []string) (string, error) {
-	if 0 == len(ethURL) {
+func SelectAndRoundEthURL(ethURL *[]string) (string, error) {
+	if 0 == len(*ethURL) {
 		return "", errors.New("NullEthURlCofigured")
 	}
 
-	result := ethURL[0]
+	result := (*ethURL)[0]
 
-	if len(ethURL) > 0 {
-		ethURL = append(ethURL[1:], result)
+	if len(*ethURL) > 0 {
+		*ethURL = append((*ethURL)[1:], result)
 	}
 	return result, nil
 }
 
-func SetupEthClient(ethURL []string) (*ethclient.Client, error) {
-	for i := 0; i < len(ethURL); i++ {
+func SetupEthClient(ethURL *[]string) (*ethclient.Client, error) {
+	for i := 0; i < len(*ethURL); i++ {
 		urlSelected, err := SelectAndRoundEthURL(ethURL)
 		if nil != err {
 			txslog.Error("SetupEthClient", "SelectAndRoundEthURL err", err.Error())


### PR DESCRIPTION
1.修改SelectAndRoundEthURL函数中存在的错误；
2.在使用ethurl之前通过接口判断该节点不处在sync状态中，否则切换节点，保证client的稳定性；