### PR TITLE
optimize sendEthereumTx

### DIFF
--- a/plugin/dapp/cross2eth/cmd/build/proxyVerifyTest.sh
+++ b/plugin/dapp/cross2eth/cmd/build/proxyVerifyTest.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2128
 # shellcheck disable=SC2086
+# shellcheck disable=SC2154
+# shellcheck disable=SC2034
+# shellcheck disable=SC2219
 # shellcheck source=/dev/null
 set -x
 set +e
@@ -16,7 +19,6 @@ function start_docker_ebrelayerProxy() {
 
     sed -i 's/^pushName=.*/pushName="x2ethproxy"/g' "./relayerproxy.toml"
 
-    # shellcheck disable=SC2154
     pushHost=$(get_docker_addr "${dockerNamePrefix}_ebrelayerproxy_1")
     sed -i 's/^pushHost=.*/pushHost="http:\/\/'"${pushHost}"':20000"/' "./relayerproxy.toml"
     sed -i 's/^pushBind=.*/pushBind="'"${pushHost}"':20000"/' "./relayerproxy.toml"
@@ -24,12 +26,10 @@ function start_docker_ebrelayerProxy() {
     # 代理转账中继器中的标志位ProcessWithDraw设置为true
     sed -i 's/^ProcessWithDraw=.*/ProcessWithDraw=true/' "./relayerproxy.toml"
 
-    # shellcheck disable=SC2154
     docker cp "./relayerproxy.toml" "${dockerNamePrefix}_ebrelayerproxy_1":/root/relayer.toml
     start_docker_ebrelayer "${dockerNamePrefix}_ebrelayerproxy_1" "/root/ebrelayer" "./ebrelayerproxy.log"
     sleep 1
 
-    # shellcheck disable=SC2154
     init_validator_relayer "${CLIP}" "${validatorPwd}" "${chain33ValidatorKeyp}" "${ethValidatorAddrKeyp}"
 }
 
@@ -40,7 +40,6 @@ function setWithdraw_ethereum() {
     cli_ret "${result}" "cfgWithdraw"
 
     # 在chain33上的bridgeBank合约中设置proxyReceiver
-    # shellcheck disable=SC2154
     ${Boss4xCLI} chain33 offline set_withdraw_proxy -c "${chain33BridgeBank}" -a "${chain33Validatorsp}" -k "${chain33DeployKey}" -n "set_withdraw_proxy:${chain33Validatorsp}"
     chain33_offline_send "set_withdraw_proxy.txt"
 }
@@ -52,7 +51,6 @@ function setWithdraw_bsc() {
     cli_ret "${result}" "cfgWithdraw"
 
     # 在chain33上的bridgeBank合约中设置proxyReceiver
-    # shellcheck disable=SC2154
     ${Boss4xCLI} chain33 offline set_withdraw_proxy -c "${chain33BridgeBank}" -a "${chain33Validatorsp}" -k "${chain33DeployKey}" -n "set_withdraw_proxy:${chain33Validatorsp}"
     chain33_offline_send "set_withdraw_proxy.txt"
 }
@@ -66,18 +64,15 @@ function TestETH2Chain33Assets_proxy() {
     local lockAmount1=$1
 
     echo -e "${IYellow} ethereumBridgeBank 初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethBridgeBankBalancebf=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}" | jq -r ".balance")
 
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     chain33RBalancebf=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33ReceiverAddr})")
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址初始金额 ${NOC}"
     chain33VspBalancebf=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33Validatorsp})")
 
     echo -e "${IYellow} lock ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${CLIP} ethereum lock -m "${lockAmount1}" -k "${ethTestAddrKey1}" -r "${chain33ReceiverAddr}")
     cli_ret "${result}" "lock"
 
@@ -86,18 +81,16 @@ function TestETH2Chain33Assets_proxy() {
 
     echo -e "${IYellow} ethereumBridgeBank lock 后金额 ${NOC}"
     result=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}")
-    # shellcheck disable=SC2219
+
     let ethBridgeBankBalanceEnd=ethBridgeBankBalancebf+lockAmount1
     cli_ret "${result}" "balance" ".balance" "${ethBridgeBankBalanceEnd}"
 
-    # shellcheck disable=SC2154
     sleep "${maturityDegree}"
 
     # chain33 chain33MainBridgeTokenAddr（ETH合约中）查询 lock 金额
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址 lock 后金额 ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33ReceiverAddr})")
-    # shellcheck disable=SC2219
+
     let chain33RBalancelock=lockAmount1*le8+chain33RBalancebf
     is_equal "${result}" "${chain33RBalancelock}"
 
@@ -106,15 +99,12 @@ function TestETH2Chain33Assets_proxy() {
     is_equal "${result}" "${chain33VspBalancebf}"
 
     echo -e "${IYellow} ethTestAddr2 ethereum withdraw 接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethT2Balancebf=$(${CLIP} ethereum balance -o "${ethTestAddr2}" | jq -r ".balance")
 
     echo -e "${IYellow} ethValidatorAddrp ethereum 代理地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethPBalancebf=$(${CLIP} ethereum balance -o "${ethValidatorAddrp}" | jq -r ".balance")
 
     echo -e "${IYellow} withdraw ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${CLIP} chain33 withdraw -m "${lockAmount1}" -k "${chain33ReceiverAddrKey}" -r "${ethTestAddr2}" -t "${chain33MainBridgeTokenAddr}")
     cli_ret "${result}" "withdraw"
 
@@ -130,7 +120,6 @@ function TestETH2Chain33Assets_proxy() {
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址 withdraw 后金额 ${NOC}"
     result=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33Validatorsp})")
-    # shellcheck disable=SC2219
     let chain33VspBalancewithdraw=lockAmount1*le8+chain33VspBalancebf
     is_equal "${result}" "${chain33VspBalancewithdraw}"
 
@@ -159,18 +148,15 @@ function TestETH2Chain33Assets_proxy_excess() {
     local lockAmount1=$1
 
     echo -e "${IYellow} ethereumBridgeBank 初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethBridgeBankBalancebf=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}" | jq -r ".balance")
 
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     chain33RBalancebf=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33ReceiverAddr})")
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址初始金额 ${NOC}"
     chain33VspBalancebf=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33Validatorsp})")
 
     echo -e "${IYellow} lock ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${CLIP} ethereum lock -m "${lockAmount1}" -k "${ethTestAddrKey1}" -r "${chain33ReceiverAddr}")
     cli_ret "${result}" "lock"
 
@@ -179,18 +165,14 @@ function TestETH2Chain33Assets_proxy_excess() {
 
     echo -e "${IYellow} ethereumBridgeBank lock 后金额 ${NOC}"
     result=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}")
-    # shellcheck disable=SC2219
     let ethBridgeBankBalanceEnd=ethBridgeBankBalancebf+lockAmount1
     cli_ret "${result}" "balance" ".balance" "${ethBridgeBankBalanceEnd}"
 
-    # shellcheck disable=SC2086
     sleep "${maturityDegree}"
 
     # chain33 chain33MainBridgeTokenAddr（ETH合约中）查询 lock 金额
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址 lock 后金额 ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33ReceiverAddr})")
-    # shellcheck disable=SC2219
     let chain33RBalancelock=lockAmount1*le8+chain33RBalancebf
     is_equal "${result}" "${chain33RBalancelock}"
 
@@ -199,15 +181,12 @@ function TestETH2Chain33Assets_proxy_excess() {
     is_equal "${result}" "${chain33VspBalancebf}"
 
     echo -e "${IYellow} ethTestAddr2 ethereum withdraw 接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethT2Balancebf=$(${CLIP} ethereum balance -o "${ethTestAddr2}" | jq -r ".balance")
 
     echo -e "${IYellow} ethValidatorAddrp ethereum 代理地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethPBalancebf=$(${CLIP} ethereum balance -o "${ethValidatorAddrp}" | jq -r ".balance")
 
     echo -e "${IYellow} withdraw ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${CLIP} chain33 withdraw -m "${lockAmount1}" -k "${chain33ReceiverAddrKey}" -r "${ethTestAddr2}" -t "${chain33MainBridgeTokenAddr}")
     cli_ret "${result}" "withdraw"
 
@@ -223,7 +202,6 @@ function TestETH2Chain33Assets_proxy_excess() {
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址 withdraw 后金额 ${NOC}"
     result=$(${Chain33Cli} evm query -a "${chain33MainBridgeTokenAddr}" -c "${chain33DeployAddr}" -b "balanceOf(${chain33Validatorsp})")
-    # shellcheck disable=SC2219
     let chain33VspBalancewithdraw=lockAmount1*le8+chain33VspBalancebf
     is_equal "${result}" "${chain33VspBalancewithdraw}"
 
@@ -246,11 +224,9 @@ function TestETH2Chain33USDT_proxy() {
     local lockAmount1=$1
 
     echo -e "${IYellow} ethereumBridgeBank 初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethBridgeBankBalancebf=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
 
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     chain33RBalancebf=$(${Chain33Cli} evm query -a "${chain33USDTBridgeTokenAddr}" -c "${chain33TestAddr1}" -b "balanceOf(${chain33ReceiverAddr})")
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址初始金额 ${NOC}"
@@ -265,7 +241,7 @@ function TestETH2Chain33USDT_proxy() {
 
     echo -e "${IYellow} 查询 ETH 这端 ethereumBridgeBank lock 后金额 ${NOC}"
     result=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}" -t "${ethereumUSDTERC20TokenAddr}")
-    # shellcheck disable=SC2219
+
     let ethBridgeBankBalanceEnd=ethBridgeBankBalancebf+lockAmount1
     cli_ret "${result}" "balance" ".balance" "${ethBridgeBankBalanceEnd}"
 
@@ -273,9 +249,8 @@ function TestETH2Chain33USDT_proxy() {
 
     # chain33 chain33MainBridgeTokenAddr（ETH合约中）查询 lock 金额
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址 lock 后金额 ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${Chain33Cli} evm query -a "${chain33USDTBridgeTokenAddr}" -c "${chain33TestAddr1}" -b "balanceOf(${chain33ReceiverAddr})")
-    # shellcheck disable=SC2219
+
     let chain33RBalancelock=lockAmount1*le8+chain33RBalancebf
     is_equal "${result}" "${chain33RBalancelock}"
 
@@ -284,11 +259,9 @@ function TestETH2Chain33USDT_proxy() {
     is_equal "${result}" "${chain33VspBalancebf}"
 
     echo -e "${IYellow} ethTestAddr2 ethereum withdraw 接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethT2Balancebf=$(${CLIP} ethereum balance -o "${ethReceiverAddr1}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
 
     echo -e "${IYellow} ethValidatorAddrp ethereum 代理地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethPBalancebf=$(${CLIP} ethereum balance -o "${ethValidatorAddrp}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
 
     echo -e "${IYellow} withdraw ${NOC}"
@@ -307,7 +280,7 @@ function TestETH2Chain33USDT_proxy() {
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址 withdraw 后金额 ${NOC}"
     result=$(${Chain33Cli} evm query -a "${chain33USDTBridgeTokenAddr}" -c "${chain33TestAddr1}" -b "balanceOf(${chain33Validatorsp})")
-    # shellcheck disable=SC2219
+
     let chain33VspBalancewithdraw=lockAmount1*le8+chain33VspBalancebf
     is_equal "${result}" "${chain33VspBalancewithdraw}"
 
@@ -318,7 +291,7 @@ function TestETH2Chain33USDT_proxy() {
 
     echo -e "${IYellow} ethValidatorAddrp ethereum 代理地址 withdraw 后金额 ${NOC}"
     result=$(${CLIP} ethereum balance -o "${ethValidatorAddrp}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
-    # shellcheck disable=SC2219
+
     let ethPBalanceEnd=ethPBalancebf-lockAmount1+1
     is_equal "${result}" "${ethPBalanceEnd}"
 
@@ -333,11 +306,9 @@ function TestETH2Chain33USDT_proxy_excess() {
     local lockAmount1=$1
 
     echo -e "${IYellow} ethereumBridgeBank 初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethBridgeBankBalancebf=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
 
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     chain33RBalancebf=$(${Chain33Cli} evm query -a "${chain33USDTBridgeTokenAddr}" -c "${chain33TestAddr1}" -b "balanceOf(${chain33ReceiverAddr})")
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址初始金额 ${NOC}"
@@ -352,7 +323,7 @@ function TestETH2Chain33USDT_proxy_excess() {
 
     echo -e "${IYellow} 查询 ETH 这端 ethereumBridgeBank lock 后金额 ${NOC}"
     result=$(${CLIP} ethereum balance -o "${ethereumBridgeBank}" -t "${ethereumUSDTERC20TokenAddr}")
-    # shellcheck disable=SC2219
+
     let ethBridgeBankBalanceEnd=ethBridgeBankBalancebf+lockAmount1
     cli_ret "${result}" "balance" ".balance" "${ethBridgeBankBalanceEnd}"
 
@@ -360,9 +331,8 @@ function TestETH2Chain33USDT_proxy_excess() {
 
     # chain33 chain33MainBridgeTokenAddr（ETH合约中）查询 lock 金额
     echo -e "${IYellow} chain33ReceiverAddr chain33 端 lock 后接收地址 lock 后金额 ${NOC}"
-    # shellcheck disable=SC2154
     result=$(${Chain33Cli} evm query -a "${chain33USDTBridgeTokenAddr}" -c "${chain33TestAddr1}" -b "balanceOf(${chain33ReceiverAddr})")
-    # shellcheck disable=SC2219
+
     let chain33RBalancelock=lockAmount1*le8+chain33RBalancebf
     is_equal "${result}" "${chain33RBalancelock}"
 
@@ -371,11 +341,9 @@ function TestETH2Chain33USDT_proxy_excess() {
     is_equal "${result}" "${chain33VspBalancebf}"
 
     echo -e "${IYellow} ethTestAddr2 ethereum withdraw 接收地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethT2Balancebf=$(${CLIP} ethereum balance -o "${ethReceiverAddr1}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
 
     echo -e "${IYellow} ethValidatorAddrp ethereum 代理地址初始金额 ${NOC}"
-    # shellcheck disable=SC2154
     ethPBalancebf=$(${CLIP} ethereum balance -o "${ethValidatorAddrp}" -t "${ethereumUSDTERC20TokenAddr}" | jq -r ".balance")
 
     echo -e "${IYellow} withdraw ${NOC}"
@@ -394,7 +362,7 @@ function TestETH2Chain33USDT_proxy_excess() {
 
     echo -e "${IYellow} chain33Validatorsp chain33 代理地址 withdraw 后金额 ${NOC}"
     result=$(${Chain33Cli} evm query -a "${chain33USDTBridgeTokenAddr}" -c "${chain33TestAddr1}" -b "balanceOf(${chain33Validatorsp})")
-    # shellcheck disable=SC2219
+
     let chain33VspBalancewithdraw=lockAmount1*le8+chain33VspBalancebf
     is_equal "${result}" "${chain33VspBalancewithdraw}"
 
@@ -410,11 +378,12 @@ function TestETH2Chain33USDT_proxy_excess() {
 }
 
 function TestProxy() {
+    # 增加一笔转帐交易测试 nonce 不一致结果是否成功
+    ${CLIP} ethereum transfer -k "${ethValidatorAddrKeyp}" -m 10 -r "${ethereumMultisignAddr}"
     TestETH2Chain33Assets_proxy 20
     TestETH2Chain33Assets_proxy 30
     TestETH2Chain33Assets_proxy_excess 100
 
-    # shellcheck disable=SC2154
     ${CLIP} ethereum token token_transfer -k "${ethTestAddrKey1}" -m 500 -r "${ethValidatorAddrp}" -t "${ethereumUSDTERC20TokenAddr}"
     TestETH2Chain33USDT_proxy 20
     TestETH2Chain33USDT_proxy 40
@@ -424,8 +393,6 @@ function TestProxy() {
 function TestRelayerProxy() {
     start_docker_ebrelayerProxy
 
-    # shellcheck disable=SC2154
-    {
         Boss4xCLI=${Boss4xCLIeth}
         CLIP=${CLIPeth}
         ethereumBridgeBank="${ethereumBridgeBankOnETH}"
@@ -443,11 +410,8 @@ function TestRelayerProxy() {
         chain33USDTBridgeTokenAddr="${chain33USDTBridgeTokenAddrOnBSC}"
         setWithdraw_bsc
         TestProxy
-    }
 }
 
-# shellcheck disable=SC2154
-# shellcheck disable=SC2034
 function parallel_test() {
     Boss4xCLI=${Boss4xCLIeth}
     CLIA=${CLIAeth}

--- a/plugin/dapp/cross2eth/ebrelayer/doc/start_ebrelayer.md
+++ b/plugin/dapp/cross2eth/ebrelayer/doc/start_ebrelayer.md
@@ -118,7 +118,7 @@ done
 #### 设置 chain33 代理地址, 及手续费设置
 ```shell
 # 设置 withdraw 的手续费及每日转帐最大值, 实时变动, 价格波动大的时候重新设置, 需要跟前端底层都商量一下
-./ebcli_A --eth_chain_name Ethereum ethereum cfgWithdraw -f 0.003 -s ETH -a 0.2 -d 18
+./ebcli_A --eth_chain_name Ethereum ethereum cfgWithdraw -f 0.003 -s ETH -a 2 -d 18
 例如:(根据需求配置, 修改手续费后要通知前端同步修改)
 ./ebcli_A --eth_chain_name Binance ethereum cfgWithdraw -f 0.00022 -s BNB -a 1.5 -d 18
 ./ebcli_A --eth_chain_name Binance ethereum cfgWithdraw -f 0.2 -s USDT -a 10000 -d 18

--- a/plugin/dapp/cross2eth/ebrelayer/doc/start_ebrelayer.md
+++ b/plugin/dapp/cross2eth/ebrelayer/doc/start_ebrelayer.md
@@ -118,7 +118,7 @@ done
 #### 设置 chain33 代理地址, 及手续费设置
 ```shell
 # 设置 withdraw 的手续费及每日转帐最大值, 实时变动, 价格波动大的时候重新设置, 需要跟前端底层都商量一下
-./ebcli_A --eth_chain_name Ethereum ethereum cfgWithdraw -f 0.003 -s ETH -a 2 -d 18
+./ebcli_A --eth_chain_name Ethereum ethereum cfgWithdraw -f 0.0016 -s ETH -a 2 -d 18
 例如:(根据需求配置, 修改手续费后要通知前端同步修改)
 ./ebcli_A --eth_chain_name Binance ethereum cfgWithdraw -f 0.00022 -s BNB -a 1.5 -d 18
 ./ebcli_A --eth_chain_name Binance ethereum cfgWithdraw -f 0.2 -s USDT -a 10000 -d 18

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
@@ -635,7 +635,7 @@ func (ethRelayer *Relayer4Ethereum) handleLogWithdraw(chain33Msg *events.Chain33
 	err = ethRelayer.sendEthereumTx(signedTx)
 	if err != nil {
 		// 如果是 nonce 出错导致的错误 再次构建交易发送
-		if err.Error() == "nonce too low" || err.Error() == "nonce too high" {
+		if err.Error() == "nonce too low" || err.Error() == "nonce too high" || strings.Index(err.Error(), "tx doesn't have the correct nonce") >= 0 {
 			relayerLog.Error("handleLogWithdraw", "sendEthereumTx err", err, "出现 nonce 错误重新构建并发送交易, chain33Txhash", chain33TxHash)
 			signedTx, err = ethRelayer.NewTransferSignTx(toAddr, intputData, value, true)
 			if err != nil {

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
@@ -589,10 +589,12 @@ func (ethRelayer *Relayer4Ethereum) handleLogWithdraw(chain33Msg *events.Chain33
 	//此处需要完成在以太坊发送以太或者ERC20数字资产的操作
 	var intputData []byte // ERC20 or BEP20 token transfer pack data
 	var toAddr common.Address
+	var senderAddr common.Address
 	var balanceOfData []byte // ERC20 or BEP20 token balanceof pack data
 
 	if tokenAddr.String() != ethtxs.EthNullAddr { //判断是否要Pack EVM数据
 		toAddr = tokenAddr
+		senderAddr = tokenAddr
 		intputData, err = ethRelayer.packTransferData(chain33Msg.EthereumReceiver, amount2transfer)
 		if err != nil {
 			relayerLog.Error("handleLogWithdraw", "CallEvmData err", err, "chain33Txhash", chain33TxHash)
@@ -609,12 +611,13 @@ func (ethRelayer *Relayer4Ethereum) handleLogWithdraw(chain33Msg *events.Chain33
 	} else {
 		//如果tokenAddr为空，则把toAddr设置为用户指定的地址
 		toAddr = chain33Msg.EthereumReceiver
+		senderAddr = ethRelayer.ethSender
 		value = amount2transfer
 	}
 
 	ethRelayer.getAvailableClient()
 	//校验余额是否充足
-	err = ethRelayer.checkBalanceEnough(toAddr, amount2transfer, balanceOfData)
+	err = ethRelayer.checkBalanceEnough(senderAddr, amount2transfer, balanceOfData)
 	if err != nil {
 		relayerLog.Error("handleLogWithdraw", "Failed to checkBalanceEnough:", err.Error(), "chain33Txhash", chain33TxHash)
 		err = errors.New("ErrBalanceNotEnough")

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
@@ -23,11 +23,6 @@ import (
 	"time"
 
 	chain33Common "github.com/33cn/chain33/common"
-
-	"github.com/bitly/go-simplejson"
-
-	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/utils"
-
 	dbm "github.com/33cn/chain33/common/db"
 	log "github.com/33cn/chain33/common/log/log15"
 	chain33Types "github.com/33cn/chain33/types"
@@ -37,10 +32,13 @@ import (
 	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs"
 	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/relayer/events"
 	ebTypes "github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/types"
+	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/utils"
+	"github.com/bitly/go-simplejson"
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 )
@@ -635,7 +633,7 @@ func (ethRelayer *Relayer4Ethereum) handleLogWithdraw(chain33Msg *events.Chain33
 	err = ethRelayer.sendEthereumTx(signedTx)
 	if err != nil {
 		// 如果是 nonce 出错导致的错误 再次构建交易发送
-		if err.Error() == "nonce too low" || err.Error() == "nonce too high" || strings.Index(err.Error(), "tx doesn't have the correct nonce") >= 0 {
+		if err == core.ErrNonceTooLow || err == core.ErrNonceTooHigh {
 			relayerLog.Error("handleLogWithdraw", "sendEthereumTx err", err, "出现 nonce 错误重新构建并发送交易, chain33Txhash", chain33TxHash)
 			signedTx, err = ethRelayer.NewTransferSignTx(toAddr, intputData, value, true)
 			if err != nil {

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
@@ -633,6 +633,7 @@ func (ethRelayer *Relayer4Ethereum) handleLogWithdraw(chain33Msg *events.Chain33
 	if err != nil {
 		// 如果是 nonce 出错导致的错误 再次构建交易发送
 		if err.Error() == "nonce too low" || err.Error() == "nonce too high" {
+			relayerLog.Error("handleLogWithdraw", "sendEthereumTx err", err, "出现 nonce 错误重新构建并发送交易, chain33Txhash", chain33TxHash)
 			signedTx, err = ethRelayer.NewTransferSignTx(toAddr, intputData, value, true)
 			if err != nil {
 				relayerLog.Error("handleLogWithdraw", "NewTransferSignTx err", err, "chain33Txhash", chain33TxHash)

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum_test.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum_test.go
@@ -97,7 +97,7 @@ func Test_All(t *testing.T) {
 }
 
 func Test_remindBalanceNotEnough(t *testing.T) {
-	ethRelayer.remindBalanceNotEnough(ethAccountAddr, "YCC")
+	ethRelayer.remindBalanceNotEnough(ethAccountAddr, "YCC", "0x....")
 }
 
 func test_GetValidatorAddr(t *testing.T) {

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/utils.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/utils.go
@@ -42,21 +42,24 @@ const (
 	EthTxPending                = EthTxStatus(2)
 )
 
-func getNonce4MultiEth(sender common.Address, client ethinterface.EthClientSpec, addr2TxNonce map[common.Address]*NonceMutex) (*big.Int, error) {
-	if nonceMutex, exist := addr2TxNonce[sender]; exist {
-		nonceMutex.RWLock.Lock()
-		defer nonceMutex.RWLock.Unlock()
-		nonceMutex.Nonce++
-		addr2TxNonce[sender] = nonceMutex
-		txslog.Debug("getNonce from cache", "address", sender.String(), "nonce", nonceMutex.Nonce)
-		return big.NewInt(nonceMutex.Nonce), nil
+// fromChain 是否从链上获取
+func getNonce4MultiEth(sender common.Address, client ethinterface.EthClientSpec, addr2TxNonce map[common.Address]*NonceMutex, fromChain bool) (*big.Int, error) {
+	if fromChain == false {
+		if nonceMutex, exist := addr2TxNonce[sender]; exist {
+			nonceMutex.RWLock.Lock()
+			defer nonceMutex.RWLock.Unlock()
+			nonceMutex.Nonce++
+			addr2TxNonce[sender] = nonceMutex
+			txslog.Debug("getNonce from cache", "address", sender.String(), "nonce", nonceMutex.Nonce)
+			return big.NewInt(nonceMutex.Nonce), nil
+		}
 	}
 
 	nonce, err := client.PendingNonceAt(context.Background(), sender)
 	if nil != err {
 		return nil, err
 	}
-	txslog.Debug("getNonce", "address", sender.String(), "nonce", nonce)
+	txslog.Debug("getNonce", "address", sender.String(), "nonce", nonce, "fromChain", fromChain)
 	n := new(NonceMutex)
 	n.Nonce = int64(nonce)
 	n.RWLock = new(sync.RWMutex)
@@ -184,7 +187,7 @@ func PrepareAuth4MultiEthereum(client ethinterface.EthClientSpec, privateKey *ec
 	auth.GasLimit = GasLimit4Deploy
 	auth.GasPrice = gasPrice
 
-	if auth.Nonce, err = getNonce4MultiEth(transactor, client, addr2TxNonce); err != nil {
+	if auth.Nonce, err = getNonce4MultiEth(transactor, client, addr2TxNonce, false); err != nil {
 		return nil, err
 	}
 
@@ -213,7 +216,7 @@ func PrepareAuth4MultiEthereumOpt(client ethinterface.EthClientSpec, privateKey 
 	auth.GasLimit = GasLimit4Deploy
 	auth.GasPrice = gasPrice
 
-	if auth.Nonce, err = getNonce4MultiEth(transactor, client, addr2TxNonce); err != nil {
+	if auth.Nonce, err = getNonce4MultiEth(transactor, client, addr2TxNonce, false); err != nil {
 		return nil, err
 	}
 
@@ -273,13 +276,13 @@ func GetEthTxStatus(client ethinterface.EthClientSpec, txhash common.Hash) strin
 	return status
 }
 
-func NewTransferTx(clientSpec ethinterface.EthClientSpec, from, to common.Address, input []byte, value *big.Int, addr2TxNonce map[common.Address]*NonceMutex) (*types.Transaction, error) {
+func NewTransferTx(clientSpec ethinterface.EthClientSpec, from, to common.Address, input []byte, value *big.Int, addr2TxNonce map[common.Address]*NonceMutex, fromChain bool) (*types.Transaction, error) {
 	price, err := clientSpec.SuggestGasPrice(context.Background())
 	if err != nil {
 		return nil, err
 	}
 
-	nonce, err := getNonce4MultiEth(from, clientSpec, addr2TxNonce)
+	nonce, err := getNonce4MultiEth(from, clientSpec, addr2TxNonce, fromChain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1、优化代理提币，当代理提币出现"nonce too low"或者"nonce too high"的错误导致发送交易失败的话，在链上获取nonce，重新构建交易后再发送。
2、修复代理打币打平台币出现金额不足的BUG。