### PR TITLE
 delete_unitTest_sendEmail

### DIFF
--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum_test.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum_test.go
@@ -468,7 +468,7 @@ func newEthRelayer(para *ethtxs.DeployPara, sim *ethinterface.SimExtend, x2EthCo
 		ethBridgeClaimChan:      ethBridgeClaimchan,
 		chain33MsgChan:          chain33Msgchan,
 		Addr2TxNonce:            make(map[common.Address]*ethtxs.NonceMutex),
-		remindUrl:               cfg.RemindUrl,
+		// remindUrl:               cfg.RemindUrl,
 	}
 
 	relayer.eventLogIndex = relayer.getLastBridgeBankProcessedHeight()


### PR DESCRIPTION
删除 cross2eth 单元测试中出错发送邮件，单元测试不发送邮件。