### PR TITLE
revert ecrecover with uncompressed pub key

### DIFF
--- a/plugin/dapp/evm/executor/vm/common/crypto/crypto.go
+++ b/plugin/dapp/evm/executor/vm/common/crypto/crypto.go
@@ -23,14 +23,18 @@ func ValidateSignatureValues(r, s *big.Int) bool {
 	return true
 }
 
-// Ecrecover 根据压缩消息和签名，返回压缩的公钥信息
+// Ecrecover 根据压缩消息和签名，返回非压缩的公钥信息
 func Ecrecover(hash, sig []byte) ([]byte, error) {
-	unpressedPub, err := ethCrypto.SigToPub(hash, sig)
+	return ethCrypto.Ecrecover(hash, sig)
+}
+
+// CompressPubKey compress pub key
+func CompressPubKey(pubKey []byte) ([]byte, error) {
+	pub, err := ethCrypto.UnmarshalPubkey(pubKey)
 	if err != nil {
 		return nil, err
 	}
-	bytes := (*btcec.PublicKey)(unpressedPub).SerializeCompressed()
-	return bytes, err
+	return ethCrypto.CompressPubkey(pub), nil
 }
 
 // SigToPub 根据签名返回公钥信息

--- a/plugin/dapp/evm/executor/vm/runtime/contracts.go
+++ b/plugin/dapp/evm/executor/vm/runtime/contracts.go
@@ -169,7 +169,9 @@ func (c *ecrecover) Run(input []byte) ([]byte, error) {
 	if driver.GetName() == eth.Name {
 		return common.LeftPadBytes(crypto.Keccak256(pubKey[1:])[12:], 32), nil
 	}
-	addrBytes, _ := driver.FromString(driver.PubKeyToAddr(pubKey))
+	// compress pub key(chain33中需使用压缩格式)
+	compressedPub, _ := crypto.CompressPubKey(pubKey)
+	addrBytes, _ := driver.FromString(driver.PubKeyToAddr(compressedPub))
 	return common.LeftPadBytes(addrBytes, 32), nil
 }
 

--- a/plugin/dapp/evm/executor/vm/runtime/ecrecover_test.go
+++ b/plugin/dapp/evm/executor/vm/runtime/ecrecover_test.go
@@ -26,7 +26,8 @@ func TestEcrecoverSignTypedMessage(t *testing.T) {
 		log15.Info("ecrecover", "failed due to", err.Error())
 		panic("ecrecover")
 	}
-
+	pubKey, err = crypto.CompressPubKey(pubKey)
+	assert.Nil(t, err)
 	//fmt.Println("ecrecover", "pubkey", common.Bytes2Hex(pubKey))
 	//fmt.Println("recoverd address", address.PubKeyToAddress(pubKey).String())
 	addr := common.PubKey2Address(pubKey)


### PR DESCRIPTION

* 还原 evm原始Ecrecover接口实现, 即返回非压缩公钥

* 非eth地址 采用chain33要求的压缩公钥