### PR TITLE
fix evmxgo ExecLocal_BurnMap cacography

### DIFF
--- a/plugin/dapp/evmxgo/executor/exec_local.go
+++ b/plugin/dapp/evmxgo/executor/exec_local.go
@@ -223,7 +223,7 @@ func (e *evmxgo) ExecLocal_Burn(payload *evmxgotypes.EvmxgoBurn, tx *types.Trans
 	return &types.LocalDBSet{KV: set}, nil
 }
 
-func (e *evmxgo) ExecLocal_BurntMap(payload *evmxgotypes.EvmxgoBurnMap, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
+func (e *evmxgo) ExecLocal_BurnMap(payload *evmxgotypes.EvmxgoBurnMap, tx *types.Transaction, receiptData *types.ReceiptData, index int) (*types.LocalDBSet, error) {
 	pay := &evmxgotypes.EvmxgoBurn{}
 	_ = copier.Copy(pay, payload)
 	return e.ExecLocal_Burn(pay, tx, receiptData, index)


### PR DESCRIPTION
修复evmxgo模块 ExecLocal_BurnMap()拼写错误。该错误会导致Exec_BurnMap()函数的执行结果不会在localDB上同步改动，使stateDB与localDB相关数据不一致。