### PR TITLE
fix(evm): reject overflow Amount in CheckTx under ForkEVMFixOverflow

### DIFF
--- a/plugin/dapp/evm/executor/evm.go
+++ b/plugin/dapp/evm/executor/evm.go
@@ -7,6 +7,7 @@ package executor
 import (
 	"bytes"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"reflect"
@@ -209,12 +210,27 @@ func (evm *EVMExecutor) createEvmContractAddress(b common.Address, nonce uint64)
 
 // CheckTx 校验交易
 func (evm *EVMExecutor) CheckTx(tx *types.Transaction, index int) error {
-	if evm.GetAPI().GetConfig().IsPara() {
+	cfg := evm.GetAPI().GetConfig()
+	if cfg.IsPara() {
 		return nil
 	}
 
 	if tx == nil {
 		return fmt.Errorf("tx empty")
+	}
+
+	// 分叉后拒绝金额超过 int64 上限的交易：
+	// EVMContractAction.Amount 为 uint64，下游记账体系为 int64，
+	// 超过 math.MaxInt64 会回绕为负数，曾导致伪 msg.value 攻击（详见 ForkEVMFixOverflow）
+	if cfg.IsDappFork(evm.GetMainHeight(), "evm", evmtypes.ForkEVMFixOverflow) {
+		var action evmtypes.EVMContractAction
+		if err := types.Decode(tx.Payload, &action); err != nil {
+			return err
+		}
+		if action.GetAmount() > math.MaxInt64 {
+			log.Error("CheckTx", "reject evm tx with amount overflow", "amount", action.GetAmount())
+			return types.ErrAmount
+		}
 	}
 
 	return state.ProcessCheck(evm.GetMainHeight(), tx.Hash())

--- a/plugin/dapp/evm/executor/evm_checktx_amount_test.go
+++ b/plugin/dapp/evm/executor/evm_checktx_amount_test.go
@@ -1,0 +1,61 @@
+// Copyright Fuzamei Corp. 2018 All Rights Reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package executor
+
+import (
+	"math"
+	"testing"
+
+	ctypes "github.com/33cn/chain33/types"
+	evmtypes "github.com/33cn/plugin/plugin/dapp/evm/types"
+	"github.com/stretchr/testify/require"
+)
+
+// makeCallTxWithAmount builds a signed evm call tx carrying the given amount.
+func makeCallTxWithAmount(cfg *ctypes.Chain33Config, amount uint64) *ctypes.Transaction {
+	action := &evmtypes.EVMContractAction{
+		Amount: amount, GasLimit: 100000, GasPrice: 1,
+		Code: nil, Para: []byte("test"),
+		ContractAddr: "0x0000000000000000000000000000000000000000",
+	}
+	tx := &ctypes.Transaction{
+		ChainID: cfg.GetChainID(),
+		Execer:  []byte(cfg.ExecName(evmtypes.ExecutorName)),
+		Payload: ctypes.Encode(action),
+		Fee:     1e6, Nonce: 0,
+	}
+	signTx(tx, roleAttacker)
+	return tx
+}
+
+// After ForkEVMFixOverflow, CheckTx must reject evm txs whose uint64 Amount
+// exceeds math.MaxInt64 (the value that used to wrap to -1 and bypass the
+// balance check, enabling the fake msg.value attack). Before the fork the
+// historical behavior is preserved (only replay check runs).
+func TestCheckTxRejectsAmountOverflow(t *testing.T) {
+	cfg := newTestConfig(t) // ForkEVMFixOverflow = 1000
+
+	// post-fork: overflow amount rejected at CheckTx
+	exec := newTestExecutor(t, cfg, 1000)
+	tx := makeCallTxWithAmount(cfg, math.MaxUint64)
+	require.Equal(t, ctypes.ErrAmount, exec.CheckTx(tx, 0))
+
+	tx = makeCallTxWithAmount(cfg, math.MaxInt64+1)
+	require.Equal(t, ctypes.ErrAmount, exec.CheckTx(tx, 0))
+
+	// post-fork: boundary and normal amounts pass
+	tx = makeCallTxWithAmount(cfg, math.MaxInt64)
+	require.NoError(t, exec.CheckTx(tx, 0))
+	tx = makeCallTxWithAmount(cfg, 1e8)
+	require.NoError(t, exec.CheckTx(tx, 0))
+	tx = makeCallTxWithAmount(cfg, 0)
+	require.NoError(t, exec.CheckTx(tx, 0))
+
+	// pre-fork: historical behavior preserved (overflow amount NOT rejected here;
+	// the exec-layer fork gate handles it on such chains)
+	execPre := newTestExecutor(t, cfg, 999)
+	tx = makeCallTxWithAmount(cfg, math.MaxUint64)
+	require.NoError(t, execPre.CheckTx(tx, 0))
+}


### PR DESCRIPTION
## Problem

`EVMContractAction.Amount` is `uint64`, but the underlying chain33 account system uses `int64`. `Amount > math.MaxInt64` wraps to a negative value downstream — the root cause of the fake `msg.value` attack (0-balance fake deposit draining real funds from bank-style contracts).

`ForkEVMFixOverflow` (d4ef8c1a) already protects the **exec layer** (`CanTransfer` rejects overflow, `Call`/`Create` revert on `Transfer` failure, token precompile guarded, transfer-only path guarded). However, `CheckTx` still performs no amount validation (`EvmType.Amount` always returns 0, so framework-level checks see nothing), letting such transactions into the mempool and into blocks where they only fail at execution.

## Fix

Under `ForkEVMFixOverflow`, `CheckTx` now decodes the action and rejects `Amount > math.MaxInt64` with `types.ErrAmount`, so overflow transactions are refused at the mempool / block-check boundary too. Since chain33 runs `CheckTx` during block execution as well, this keeps malicious txs out of blocks entirely on fork-active chains.

Pre-fork behavior is intentionally unchanged (consensus compatibility).

## Tests

New `TestCheckTxRejectsAmountOverflow`:
- post-fork: `MaxUint64` and `MaxInt64+1` rejected with `ErrAmount`
- post-fork: `MaxInt64`, `1e8`, `0` accepted
- pre-fork: `MaxUint64` still accepted by `CheckTx` (historical behavior; exec-layer gate handles it there)

`go test -ldflags=-checklinkname=0 ./plugin/dapp/evm/executor/` — all pass (including the existing `TestWBTYOverflowAttackIntegration`).