### PR TITLE
fix(ci): fix semantic-release preset and extra_plugins

### DIFF
--- a/.github/workflows/automake.yml
+++ b/.github/workflows/automake.yml
@@ -39,8 +39,7 @@ jobs:
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint
-            @semantic-release-replace-plugin
+            semantic-release-replace-plugin
             @semantic-release/exec
             @semantic-release/changelog
             @semantic-release/git

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           branch: master
           extra_plugins: |
-            conventional-changelog/conventional-changelog-jshint
             semantic-release-replace-plugin@1.2.7
             @semantic-release/exec@6
             @semantic-release/changelog@6

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -3,13 +3,13 @@
     [
         "@semantic-release/commit-analyzer",
       {
-        "preset": "jshint"
+        "preset": "angular"
       }
     ],
     [
         "@semantic-release/release-notes-generator",
       {
-        "preset": "jshint"
+        "preset": "angular"
       }
     ],
     [


### PR DESCRIPTION
## 修复内容

### 1. `.releaserc.yml` — preset `jshint` → `angular`

仓库的 commit message 全部是 Angular 格式（`fix(ci): ...`、`feat: ...` 等），jshint preset 的格式是 `[[Type]] description`，两者完全不匹配。同时 `@semantic-release/commit-analyzer` v13 使用 ESM，而通过 GitHub shorthand 安装的 `conventional-changelog-jshint` 会解析到 2016 年废弃的 v0.1.0（CommonJS callback API），导致 TypeError 崩溃。

### 2. `release.yml` — 删除 `conventional-changelog/conventional-changelog-jshint`

GitHub shorthand 格式（`org/repo`）解析到废弃的 v0.1.0，与 commit-analyzer v13 不兼容，是崩溃根因。`angular` preset 已内置于 commit-analyzer，不需要额外插件。

### 3. `automake.yml` — 删除 jshint 行 + 修正拼写错误

- 同上删除 jshint 插件
- `@semantic-release-replace-plugin` → `semantic-release-replace-plugin`（多了一个 `@` 前缀，导致 npm 包名解析错误，实际安装的是 `@semantic-release` scope 下不存在的包）

## 背景

`33cn/chain33` 的相同问题已通过 PR #1389（preset 修复）和 PR #1390（admin GH_TOKEN）修复，本 PR 将相同的修复同步到 plugin 仓库。plugin 仓库已通过 `gh secret set` 写入了具备 admin 权限的 `GH_TOKEN` secret，可绕过保护分支直接推送发版 commit。

🤖 Generated with [Claude Code](https://claude.com/claude-code)