### PR TITLE
fix(cross2eth): reuse broadcast lock tx on ebcli retry to prevent double mint

### DIFF
--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethereum.go
@@ -339,6 +339,11 @@ func (ethRelayer *Relayer4Ethereum) LockEthErc20AssetAsync(ownerPrivateKey, toke
 	return ethtxs.LockEthErc20AssetAsync(ownerPrivateKey, tokenAddr, chain33Receiver, bn, ethRelayer.clientSpec, ethRelayer.x2EthContracts.BridgeBank, ethRelayer.Addr2TxNonce)
 }
 
+// WaitLockTx 等待已广播的 lock 交易确认成功，用于调用方重试时复用交易，防止重复锁定
+func (ethRelayer *Relayer4Ethereum) WaitLockTx(txhash string) (string, error) {
+	return ethtxs.WaitLockTxConfirmed(ethRelayer.clientSpec, common.HexToHash(txhash), ethRelayer.providerHttp[0])
+}
+
 // ShowTxReceipt ...
 func (ethRelayer *Relayer4Ethereum) ShowTxReceipt(hash string) (*types.Receipt, error) {
 	txhash := common.HexToHash(hash)

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/auxiliary.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/auxiliary.go
@@ -3,6 +3,7 @@ package ethtxs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 
@@ -238,6 +239,23 @@ func TransferEth(fromPrivateKeyStr, toAddr string, amount *big.Int, client ethin
 	return signedTx.Hash().String(), nil
 }
 
+// LockBroadcastError 表示 lock 交易已广播到以太坊网络，但未能确认执行结果。
+// 携带已广播交易的 hash，供调用方记录并在重试时复用该交易，避免重复锁定导致重复铸币。
+type LockBroadcastError struct {
+	TxHash common.Hash
+	Err    error
+}
+
+// Error ...
+func (e *LockBroadcastError) Error() string {
+	return fmt.Sprintf("lock tx %s broadcast but unconfirmed: %s", e.TxHash.Hex(), e.Err.Error())
+}
+
+// Unwrap ...
+func (e *LockBroadcastError) Unwrap() error {
+	return e.Err
+}
+
 // LockEthErc20Asset ...
 func LockEthErc20Asset(ownerPrivateKeyStr, tokenAddrStr, chain33Receiver string, amount *big.Int, client ethinterface.EthClientSpec, bridgeBank *generated.BridgeBank, bridgeBankAddr common.Address, addr2TxNonce map[common.Address]*NonceMutex, providerHttp string) (string, error) {
 	var prepareDone bool
@@ -306,12 +324,17 @@ func LockEthErc20Asset(ownerPrivateKeyStr, tokenAddrStr, chain33Receiver string,
 	tx, err := bridgeBank.Lock(auth, recvAddr.Hash160[:], tokenAddr, amount)
 	if nil != err {
 		txslog.Error("LockEthErc20Asset", "lock err", err.Error())
+		// 交易可能已广播（SendTransaction 报错但交易已进入节点 mempool），
+		// 携带 tx hash 返回，供上层在重试时复用该交易，防止重复锁定
+		if nil != tx {
+			return "", &LockBroadcastError{TxHash: tx.Hash(), Err: err}
+		}
 		return "", err
 	}
 	err = waitEthTxFinished(client, tx.Hash(), "LockEthErc20Asset", providerHttp)
 	if nil != err {
 		txslog.Error("LockEthErc20Asset", "waitEthTxFinished err", err.Error())
-		return "", err
+		return "", &LockBroadcastError{TxHash: tx.Hash(), Err: err}
 	}
 
 	return tx.Hash().String(), nil

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/ethtxs_test.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/ethtxs_test.go
@@ -3,6 +3,7 @@ package ethtxs
 import (
 	"context"
 	"crypto/ecdsa"
+	"errors"
 	"fmt"
 	"math/big"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -53,6 +55,42 @@ func Test_GetAddressFromBridgeRegistry(t *testing.T) {
 	bridgebankTest := ContractRegistry(5)
 	_, err := GetAddressFromBridgeRegistry(sim, genesisAddr, genesisAddr, bridgebankTest)
 	require.NotNil(t, err)
+}
+
+// Test_WaitLockTxConfirmedAndBroadcastError 验证 lock 交易广播后确认失败时，
+// 可通过 LockBroadcastError 携带的 tx hash 复用该交易，防止重试重复锁定。
+func Test_WaitLockTxConfirmedAndBroadcastError(t *testing.T) {
+	genesiskey, _ := crypto.GenerateKey()
+	alloc := make(core.GenesisAlloc)
+	genesisAddr := crypto.PubkeyToAddress(genesiskey.PublicKey)
+	genesisAccount := core.GenesisAccount{
+		Balance:    big.NewInt(1000000000000 * 10000),
+		PrivateKey: crypto.FromECDSA(genesiskey),
+	}
+	alloc[genesisAddr] = genesisAccount
+	sim := new(ethinterface.SimExtend)
+	sim.SimulatedBackend = backends.NewSimulatedBackend(alloc, uint64(100000000))
+
+	// 广播并确认一笔真实交易，WaitLockTxConfirmed 应返回原 hash，重试可复用
+	auth, err := bind.NewKeyedTransactorWithChainID(genesiskey, big.NewInt(1337))
+	require.NoError(t, err)
+	nonce, err := sim.PendingNonceAt(context.Background(), genesisAddr)
+	require.NoError(t, err)
+	receiver := common.HexToAddress("0x000000000000000000000000000000000000dead")
+	tx := types.NewTransaction(nonce, receiver, big.NewInt(1), 21000, big.NewInt(1e9), nil)
+	signedTx, err := auth.Signer(genesisAddr, tx)
+	require.NoError(t, err)
+	require.NoError(t, sim.SendTransaction(context.Background(), signedTx))
+
+	hash, err := WaitLockTxConfirmed(sim, signedTx.Hash(), "")
+	require.NoError(t, err)
+	assert.Equal(t, signedTx.Hash().Hex(), hash)
+
+	// LockBroadcastError 携带已广播交易的 hash，errors.As 可提取用于去重记录
+	broadcastErr := &LockBroadcastError{TxHash: signedTx.Hash(), Err: errors.New("rpc timeout")}
+	var asErr *LockBroadcastError
+	require.True(t, errors.As(broadcastErr, &asErr))
+	assert.Equal(t, signedTx.Hash().Hex(), asErr.TxHash.Hex())
 }
 
 func Test_RelayOracleClaimToEthereum(t *testing.T) {

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/utils.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs/utils.go
@@ -29,6 +29,10 @@ var (
 	addr2Nonce            = make(map[common.Address]NonceMutex)
 	ErrGetSuggestGasPrice = errors.New("ErrGetSuggestGasPrice")
 	ErrNodeNetwork        = errors.New("ErrNodeNetwork")
+	// ErrLockTxFailed 已广播的 lock 交易在链上确认失败（回滚）
+	ErrLockTxFailed = errors.New("lock tx confirmed but reverted")
+	// ErrLockTxPending 已广播的 lock 交易尚未确认
+	ErrLockTxPending = errors.New("lock tx still pending")
 )
 
 // String ...
@@ -39,6 +43,7 @@ func (ethTxStatus EthTxStatus) String() string {
 // const
 const (
 	PendingDuration4TxExeuction = 300
+	EthTxSuccess                = EthTxStatus(1)
 	EthTxPending                = EthTxStatus(2)
 )
 
@@ -274,6 +279,23 @@ func GetEthTxStatus(client ethinterface.EthClientSpec, txhash common.Hash) strin
 	}
 
 	return status
+}
+
+// WaitLockTxConfirmed 等待已广播的 lock 交易确认成功并返回其 hash。
+// 返回 ErrLockTxFailed 表示交易已确认但执行失败（回滚），调用方可安全地重新执行 lock；
+// 返回 ErrLockTxPending 或其他错误表示交易尚未确认，调用方可稍后重试复用同一笔交易。
+func WaitLockTxConfirmed(client ethinterface.EthClientSpec, txhash common.Hash, providerHttp string) (string, error) {
+	if err := waitEthTxFinished(client, txhash, "WaitLockTxConfirmed", providerHttp); nil != err {
+		return "", err
+	}
+	status := GetEthTxStatus(client, txhash)
+	if status == EthTxSuccess.String() {
+		return txhash.Hex(), nil
+	}
+	if status == EthTxPending.String() {
+		return "", ErrLockTxPending
+	}
+	return "", ErrLockTxFailed
 }
 
 func NewTransferTx(clientSpec ethinterface.EthClientSpec, from, to common.Address, input []byte, value *big.Int, addr2TxNonce map[common.Address]*NonceMutex, fromChain bool) (*types.Transaction, error) {

--- a/plugin/dapp/cross2eth/ebrelayer/relayer/manager.go
+++ b/plugin/dapp/cross2eth/ebrelayer/relayer/manager.go
@@ -5,8 +5,10 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	chain33Address "github.com/33cn/chain33/common/address"
 	ethCommon "github.com/ethereum/go-ethereum/common"
@@ -17,6 +19,7 @@ import (
 	chain33Types "github.com/33cn/chain33/types"
 	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/relayer/chain33"
 	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum"
+	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/relayer/ethereum/ethtxs"
 	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/relayer/events"
 	relayerTypes "github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/types"
 	"github.com/33cn/plugin/plugin/dapp/cross2eth/ebrelayer/utils"
@@ -26,6 +29,22 @@ import (
 var (
 	mlog = log15.New("relayer manager", "manager")
 )
+
+// 已广播的 lock 交易记录。ebcli 的同步 lock 命令在 rpc 失败时会重试（最多 3 次），
+// 若上一次调用已把 lock 交易广播到以太坊，重试必须复用该交易而不是重新执行，
+// 否则同一笔资产会被锁定两次，导致 chain33 端重复铸币。
+type pendingLockRecord struct {
+	txHash string
+	stamp  time.Time
+}
+
+var (
+	pendingLocksMu sync.Mutex
+	pendingLocks   = make(map[string]*pendingLockRecord)
+)
+
+// pendingLockTTL 记录的有效期，过期记录视为失效，重新执行 lock
+const pendingLockTTL = 10 * time.Minute
 
 // status ...
 const (
@@ -556,6 +575,18 @@ func (manager *Manager) LockEthErc20AssetAsync(lockEthErc20Asset *relayerTypes.L
 	return nil
 }
 
+// recordPendingLock 记录已广播的 lock 交易，并顺带清理过期记录
+func recordPendingLock(key string, rec *pendingLockRecord) {
+	pendingLocksMu.Lock()
+	defer pendingLocksMu.Unlock()
+	for k, v := range pendingLocks {
+		if time.Since(v.stamp) >= pendingLockTTL {
+			delete(pendingLocks, k)
+		}
+	}
+	pendingLocks[key] = rec
+}
+
 // LockEthErc20Asset ...
 func (manager *Manager) LockEthErc20Asset(lockEthErc20Asset *relayerTypes.LockEthErc20, result *interface{}) error {
 	manager.mtx.Lock()
@@ -567,10 +598,50 @@ func (manager *Manager) LockEthErc20Asset(lockEthErc20Asset *relayerTypes.LockEt
 	if !ok {
 		return errors.New("no Ethereum chain named as you configured")
 	}
+
+	// 以链名+锁定参数作为幂等键：同一笔 lock 的重试复用已广播的交易，防止重复锁定
+	lockKey := strings.Join([]string{
+		lockEthErc20Asset.ChainName,
+		lockEthErc20Asset.OwnerKey,
+		lockEthErc20Asset.TokenAddr,
+		lockEthErc20Asset.Amount,
+		lockEthErc20Asset.Chain33Receiver,
+	}, "|")
+
+	pendingLocksMu.Lock()
+	rec, exist := pendingLocks[lockKey]
+	valid := exist && time.Since(rec.stamp) < pendingLockTTL
+	pendingLocksMu.Unlock()
+	if valid {
+		hash, err := ethInt.WaitLockTx(rec.txHash)
+		if nil == err {
+			*result = rpctypes.Reply{
+				IsOk: true,
+				Msg:  hash,
+			}
+			return nil
+		}
+		// 已广播的交易确认失败（回滚），删除记录重新执行 lock
+		if errors.Is(err, ethtxs.ErrLockTxFailed) {
+			pendingLocksMu.Lock()
+			delete(pendingLocks, lockKey)
+			pendingLocksMu.Unlock()
+		} else {
+			// 交易仍在确认中，保留记录，返回错误让调用方稍后重试
+			return err
+		}
+	}
+
 	txhash, err := ethInt.LockEthErc20Asset(lockEthErc20Asset.OwnerKey, lockEthErc20Asset.TokenAddr, lockEthErc20Asset.Amount, lockEthErc20Asset.Chain33Receiver)
 	if nil != err {
+		// 交易已广播但确认失败：记录 tx hash，重试时复用该交易
+		var broadcastErr *ethtxs.LockBroadcastError
+		if errors.As(err, &broadcastErr) {
+			recordPendingLock(lockKey, &pendingLockRecord{txHash: broadcastErr.TxHash.Hex(), stamp: time.Now()})
+		}
 		return err
 	}
+	recordPendingLock(lockKey, &pendingLockRecord{txHash: txhash, stamp: time.Now()})
 	*result = rpctypes.Reply{
 		IsOk: true,
 		Msg:  txhash,


### PR DESCRIPTION
## Context

ci_cross2eth failed on run https://github.com/33cn/plugin/actions/runs/33836471133/job/100909914007?pr=1312 (branch fix-token-duplicate-finishcreate), while the pull_request run of the **same commit** passed — a timing flake, not a regression from that PR.

Failure: `TestETH2Chain33USDT_proxy_excess` (BSC side) — after a single `ethereum lock -m 100`, the bridge bank balance went 140 → 340 (expected 240). Two locks executed.

## Root cause

ebcli's sync `lock` command retries the whole `Manager.LockEthErc20Asset` rpc up to 3 times on error (commit 857c01f98). The flow is not idempotent (approve + lock txs). In the failing run the first attempt's Lock tx was broadcast/mined but the handler reported a transient error (26s wall time fits a send-stage rpc error: ~10s attempt 1 + 0.5s retry sleep + ~15s attempt 2), so the retry re-executed the lock — locking the same asset twice on ETH/BSC and minting 2x on the chain33 side.

## Fix

Make the sync lock idempotent across retries in the ebrelayer:

- `ethtxs.LockEthErc20Asset` now returns `LockBroadcastError` carrying the tx hash at the two post-broadcast error points (lock send error with non-nil tx, and receipt-wait failure).
- New `ethtxs.WaitLockTxConfirmed` waits for a recorded tx and distinguishes confirmed-success / confirmed-failed (`ErrLockTxFailed`) / still-pending (`ErrLockTxPending`).
- `manager.LockEthErc20Asset` records broadcast lock txs keyed by chain+owner+token+amount+receiver (10min TTL, swept on write). On retry with the same params it waits for the recorded tx instead of re-locking; only a definitively reverted tx is re-executed.

This also protects against the rpc-reply-lost-after-success case, at the cost of an idempotency window: an identical lock request within the TTL returns the first tx hash.

## Tests

- New `Test_WaitLockTxConfirmedAndBroadcastError` in ethtxs (simulator): wait-on-recorded-hash returns the same hash; `LockBroadcastError` carries the hash via `errors.As`.
- `go test ./plugin/dapp/cross2eth/ebrelayer/...` all pass.
- ci_cross2eth (docker e2e, ~40min) is the end-to-end verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)